### PR TITLE
Added note on using sourcedialog plugin in an item-by-item toolbar

### DIFF
--- a/guides/dev/features/sourcearea/README.md
+++ b/guides/dev/features/sourcearea/README.md
@@ -33,6 +33,18 @@ If you want to use it in an inline editor instance (which by default uses floati
 
 	config.extraPlugins = 'sourcedialog';
 	
+If you are using [an "item by item" toolbar configuration](#!/guide/dev_toolbar-section-%22item-by-item%22-configuration), note that the button name for the source dialog is `Sourcedialog`:
+
+	config.toolbar = [
+		//... other toolbar groups
+		{name: 'tools', items: ['Sourcedialog']}
+	];
+	//or, using the alternate syntax
+	config.toolbar = [
+		//... other toolbar groups
+		['Sourcedialog']
+	];
+
 If, on the other hand, you want to replace the default source editing area with the source dialog for classic editor with fixed user interface, use the following settings:
 
 	config.extraPlugins = 'sourcedialog';


### PR DESCRIPTION
When configuring the toolbar for an editor, using a button named `Source` is prevalent in the docs, but I guess this only works for the `sourcearea` plugin though. When using the `sourcedialog` plugin (as required with the inline-editor), the button name needs to be `Sourcedialog`.

As discussed at http://ckeditor.com/forums/CKEditor/Source-button-not-visible-when-inline-editing