### PR TITLE
Fixed invalid JSON markup

### DIFF
--- a/guides/guides.json
+++ b/guides/guides.json
@@ -685,14 +685,6 @@
 						"meta_description": "Introduction to CKEditor Widgets.",
 						"meta_keywords": "ckeditor, editor, wysiwyg, widgets, widget, plugin, plugins"
 					},
-//					{
-//						"name": "dev_files",
-//						"url": "dev/deep_dive/files",
-//						"title": "Files Handling",
-//						"description": "Introduction to CKEditor Files Handling and Files Tools.",
-//						"meta_description": "Introduction to CKEditor Files Handling and Files Tools.",
-//						"meta_keywords": "ckeditor, editor, wysiwyg, file, files, tools, clipboard"
-//					},
 					{
 						"name": "dev_clipboard",
 						"url": "dev/deep_dive/clipboard",


### PR DESCRIPTION
There were comments in JSON file, that was most likely a reason for ckeditor/ckeditor-sdk#167.