### PR TITLE
Update the "Embedding Media Resources with oEmbed" for 4.6.1.

### DIFF
--- a/guides/dev/deep_dive/errors/README.md
+++ b/guides/dev/deep_dive/errors/README.md
@@ -39,7 +39,7 @@ This article contains the list of CKEditor error codes and their explanation. Th
 
 ## embed-no-provider-url
 * Location: `plugins/embed/plugin.js`
-* Description: No embed provider URL [configured](http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-embed_provider). Since 4.7.0 this value is empty by default.
+* Description: No [embed provider URL](http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-embed_provider) configured. Since CKEditor 4.7.0 this value is empty by default.
 * Additional data: None.
 
 ## embedbase-widget-invalid

--- a/guides/dev/deep_dive/errors/README.md
+++ b/guides/dev/deep_dive/errors/README.md
@@ -37,6 +37,11 @@ This article contains the list of CKEditor error codes and their explanation. Th
 	* `plugin`: The name of the plugin that cannot be removed.
 	* `requiredBy`: The name of the plugin whose requirements block the removal.
 
+## embed-no-provider-url
+* Location: `plugins/embed/plugin.js`
+* Description: No embed provider URL configured. Since 4.6.0 this value is empty by default.
+* Additional data: None.
+
 ## embedbase-widget-invalid
 
 * Location: `plugins/embedbase/plugin.js`

--- a/guides/dev/deep_dive/errors/README.md
+++ b/guides/dev/deep_dive/errors/README.md
@@ -39,7 +39,7 @@ This article contains the list of CKEditor error codes and their explanation. Th
 
 ## embed-no-provider-url
 * Location: `plugins/embed/plugin.js`
-* Description: No embed provider URL configured. Since 4.6.0 this value is empty by default.
+* Description: No embed provider URL [configured](http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-embed_provider). Since 4.7.0 this value is empty by default.
 * Additional data: None.
 
 ## embedbase-widget-invalid

--- a/guides/dev/features/embed/README.md
+++ b/guides/dev/features/embed/README.md
@@ -14,7 +14,7 @@ The optional [Media Embed](http://ckeditor.com/addon/embed) and [Semantic Media 
 Both widgets allow to embed resources (videos, images, tweets, etc.) hosted by other services (called the "content providers") in the editor. By default the plugins use the [Iframely](https://iframely.com/) proxy service which supports over [1715 content providers](https://iframely.com/domains) such as [YouTube](http://youtube.com), [Vimeo](http://vimeo.com), [Twitter](http://twitter.com), [Instagram](http://instagtram.com), [Imgur](http://imgur.com), [GitHub](http://github.com), or [Google Maps](maps.google.com).
 
 <p class="tip">
-  Since 4.6 the content provider URL is set to empty by default. The former default URL is still available, although i'ts recommended to set up an account on the [Iframely](https://iframely.com/) service for better API usage tracking.
+  Since 4.7 the content provider URL is set to empty by default. The former default URL is still available, although it's recommended to set up an account on the [Iframely](https://iframely.com/) service for better control over embedded content.
 </p>
 
 ## Media Embed vs Semantic Media Embed
@@ -43,7 +43,7 @@ Both widgets can be easily [configured](#!/api/CKEDITOR.config-cfg-embed_provide
 
 ## Adjusting the Content Provider
 
-As of 4.6 there is no default content provider for the Media Embed and Semantic Media Embed plugins, atlthough the former default anonymized API endpoint is still available for use. This service is provided by [Iframely](https://iframely.com/) and allows for 1000 hits a month. For better control of API usage it is recommended to [set up an account at Iframely](https://iframely.com/plans). The free "Developer" tier comes with similar set of features and restrictions.
+As of 4.7 there is no default content provider for the Media Embed and Semantic Media Embed plugins, although the former default anonymized API endpoint is still available for use. This service is provided by [Iframely](https://iframely.com/) and allows for 1000 hits a month. For better control of API usage it is recommended to [set up an account at Iframely](https://iframely.com/plans). The free "Developer" tier comes with similar set of features and restrictions.
 
 Iframely can also be configured to be hosted on your server &mdash; you can read more about it in the ["Self-host Iframely APIs"](https://iframely.com/docs/host) article.
 
@@ -55,9 +55,6 @@ Iframely can also be configured to be hosted on your server &mdash; you can read
 		Some services (like Google Maps) require setting up your API key, too. The default account used by the plugins is just for demonstration purposes. In Google API Settings, "Accept requests from these HTTP referrers (web sites)" is set to accept only <code>ckeditor.com</code>.
 	</p>
 </div>
-<p class="tip">
-	The pre-4.6 default configuration using the public Iframely service does not support SSL. If you need SSL support, you should either host Iframely locally on your server or use the public service through the <a href="http://iframe.ly">iframe.ly</a> domain with your own API key.
-</p>
 
 ## Automatic Embedding on Paste
 

--- a/guides/dev/features/embed/README.md
+++ b/guides/dev/features/embed/README.md
@@ -13,6 +13,10 @@ The optional [Media Embed](http://ckeditor.com/addon/embed) and [Semantic Media 
 
 Both widgets allow to embed resources (videos, images, tweets, etc.) hosted by other services (called the "content providers") in the editor. By default the plugins use the [Iframely](https://iframely.com/) proxy service which supports over [1715 content providers](https://iframely.com/domains) such as [YouTube](http://youtube.com), [Vimeo](http://vimeo.com), [Twitter](http://twitter.com), [Instagram](http://instagtram.com), [Imgur](http://imgur.com), [GitHub](http://github.com), or [Google Maps](maps.google.com).
 
+<p class="tip">
+  Since 4.6 the content provider URL is set to empty by default. The former default URL is still available, although i'ts recommended to set up an account on the [Iframely](https://iframely.com/) service for better API usage tracking.
+</p>
+
 ## Media Embed vs Semantic Media Embed
 
 The difference between Media Embed and Semantic Media Embed is that the first will include the entire HTML needed to display the resource in the data, while the latter will only include an `<oembed>` tag with the URL to the resource. See the following examples:
@@ -37,9 +41,9 @@ This difference makes the Media Embed plugin perfect for systems where the embed
 
 Both widgets can be easily [configured](#!/api/CKEDITOR.config-cfg-embed_provider) to use another [oEmbed](http://www.oembed.com/) provider or custom services.
 
-## Adjusting the Default Content Provider
+## Adjusting the Content Provider
 
-The default configuration of the Media Embed and Semantic Media Embed plugins uses the public service provided by [Iframely](https://iframely.com/). By default an anonymized API endpoint is configured which allows for 1000 hits a month. For better control of API usage it is recommended to [set up an account at Iframely](https://iframely.com/plans) and use your private API key. The free "Developer" tier comes with similar set of features and restrictions.
+As of 4.6 there is no default content provider for the Media Embed and Semantic Media Embed plugins, atlthough the former default anonymized API endpoint is still available for use. This service is provided by [Iframely](https://iframely.com/) and allows for 1000 hits a month. For better control of API usage it is recommended to [set up an account at Iframely](https://iframely.com/plans). The free "Developer" tier comes with similar set of features and restrictions.
 
 Iframely can also be configured to be hosted on your server &mdash; you can read more about it in the ["Self-host Iframely APIs"](https://iframely.com/docs/host) article.
 
@@ -51,6 +55,9 @@ Iframely can also be configured to be hosted on your server &mdash; you can read
 		Some services (like Google Maps) require setting up your API key, too. The default account used by the plugins is just for demonstration purposes. In Google API Settings, "Accept requests from these HTTP referrers (web sites)" is set to accept only <code>ckeditor.com</code>.
 	</p>
 </div>
+<p class="tip">
+	The pre-4.6 default configuration using the public Iframely service does not support SSL. If you need SSL support, you should either host Iframely locally on your server or use the public service through the <a href="http://iframe.ly">iframe.ly</a> domain with your own API key.
+</p>
 
 ## Automatic Embedding on Paste
 

--- a/guides/dev/features/embed/README.md
+++ b/guides/dev/features/embed/README.md
@@ -14,7 +14,7 @@ The optional [Media Embed](http://ckeditor.com/addon/embed) and [Semantic Media 
 Both widgets allow to embed resources (videos, images, tweets, etc.) hosted by other services (called the "content providers") in the editor. By default the plugins use the [Iframely](https://iframely.com/) proxy service which supports over [1715 content providers](https://iframely.com/domains) such as [YouTube](http://youtube.com), [Vimeo](http://vimeo.com), [Twitter](http://twitter.com), [Instagram](http://instagtram.com), [Imgur](http://imgur.com), [GitHub](http://github.com), or [Google Maps](maps.google.com).
 
 <p class="tip">
-  Since 4.7 the content provider URL is set to empty by default. The former default URL is still available, although it's recommended to set up an account on the [Iframely](https://iframely.com/) service for better control over embedded content.
+  Since 4.7 the content provider URL is set to empty by default. The former default URL is still available, although it's recommended to set up an account on the <a href="https://iframely.com/">Iframely</a> service for better control over embedded content.
 </p>
 
 ## Media Embed vs Semantic Media Embed
@@ -41,20 +41,11 @@ This difference makes the Media Embed plugin perfect for systems where the embed
 
 Both widgets can be easily [configured](#!/api/CKEDITOR.config-cfg-embed_provider) to use another [oEmbed](http://www.oembed.com/) provider or custom services.
 
-## Adjusting the Content Provider
+As of 4.7 there is no default content provider for the Media Embed and Semantic Media Embed plugins.
 
-As of 4.7 there is no default content provider for the Media Embed and Semantic Media Embed plugins, although the former default anonymized API endpoint is still available for use. This service is provided by [Iframely](https://iframely.com/) and allows for 1000 hits a month. For better control of API usage it is recommended to [set up an account at Iframely](https://iframely.com/plans). The free "Developer" tier comes with similar set of features and restrictions.
+Formerly CKEditor has been using anonymized endpoint provided by [Iframely](https://iframely.com/), however it did not include several features such as Google Maps. It's still possible to use it, you'll find it in [configuration option](#!/api/CKEDITOR.config-cfg-embed_provider) documentation, however for better control of API usage it is recommended to [set up an account at Iframely](https://iframely.com/plans). The free "Developer" tier does not have this restriction.
 
 Iframely can also be configured to be hosted on your server &mdash; you can read more about it in the ["Self-host Iframely APIs"](https://iframely.com/docs/host) article.
-
-<div class="tip">
-	<p>
-		The default configuration using the public Iframely service does not support SSL. If you need SSL support, you should either host Iframely locally on your server or use the public service through the <a href="http://iframe.ly">iframe.ly</a> domain with your own API key.
-	</p>
-	<p>
-		Some services (like Google Maps) require setting up your API key, too. The default account used by the plugins is just for demonstration purposes. In Google API Settings, "Accept requests from these HTTP referrers (web sites)" is set to accept only <code>ckeditor.com</code>.
-	</p>
-</div>
 
 ## Automatic Embedding on Paste
 


### PR DESCRIPTION
With the next major release the `CKEDITOR.config.embed_provider` option's default value is going t obe set to an empty string, so appropriate changes had to be made in the guide.

Relevant Trac ticket:
http://dev.ckeditor.com/ticket/13793
