### PR TITLE
Update grunt file to have no warnings.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function( grunt ) {
 					'head-html-common': 'source/head-html-common.html',
 					footer: 'Copyright &copy; 2003-2017, <a href=\"http://cksource.com\" style=\"color:#085585\">CKSource</a> - Frederico Knabben. All rights reserved. | <a href=\"LICENSE.html\" style=\"color:#085585\">License</a> | Generated with <a href=\"https://github.com/senchalabs/jsduck\">JSDuck</a>.',
 					tags: 'source/customs.rb',
-					warnings: ['-nodoc', '-image_unused', '-link:guides/dev/code_documentation'],
+					warnings: [ '-nodoc', '-image_unused' ],
 					welcome: 'source/welcome.html',
 					guides: grunt.option( 'guides' ) || 'guides/guides.json',
 					output: 'build',

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -56,12 +56,13 @@ module.exports = function( grunt ) {
 					'head-html-common': 'source/head-html-common.html',
 					footer: 'Copyright &copy; 2003-2017, <a href=\"http://cksource.com\" style=\"color:#085585\">CKSource</a> - Frederico Knabben. All rights reserved. | <a href=\"LICENSE.html\" style=\"color:#085585\">License</a> | Generated with <a href=\"https://github.com/senchalabs/jsduck\">JSDuck</a>.',
 					tags: 'source/customs.rb',
-					warnings: '-nodoc',
+					warnings: ['-nodoc', '-image_unused', '-link:guides/dev/code_documentation'],
 					welcome: 'source/welcome.html',
 					guides: grunt.option( 'guides' ) || 'guides/guides.json',
 					output: 'build',
 					external: 'Blob,File,FileReader,DocumentFragment',
-					exclude: '<%= path %>/plugins/codesnippet/lib'
+					exclude: '<%= path %>/plugins/codesnippet/lib',
+					'ignore-html': 'source'
 				}
 			}
 		}

--- a/guides/dev/code_documentation/README.md
+++ b/guides/dev/code_documentation/README.md
@@ -126,7 +126,7 @@ The following is an example of property documentation.
 	 * A unique identifier of this editor instance.
 	 *
 	 * **Note:** It will be originated from the ID or the name
-	 * attribute of the {@link #element}, otherwise a name pattern of
+	 * attribute of the `element`, otherwise a name pattern of
 	 * 'editor{n}' will be used.
 	 *
 	 * @private


### PR DESCRIPTION
* Unused images won't throw warning any longer
* There is example code in `guides/dev/code_documentation` path, which log warning `{@link #element} links to non-existing class`. Currently linking problem will be skipped in this particular place.
* `<source>` tag will be ignored, JSDuck see it as unclosed.

Note: Solution is not perfect and just cover current warnings.
Closes #96 


