### PR TITLE
Typo in file name at Browser Hacks page

### DIFF
--- a/guides/skin_sdk/browser_hacks/README.md
+++ b/guides/skin_sdk/browser_hacks/README.md
@@ -9,7 +9,7 @@ Skins are basically CSS styling on the DOM structure that represents the editor.
 
 But still the world is not perfect and we have small differences on CSS among browsers. Additionally, CKEditor must support ancient browsers, which are more limited and buggy.
 
-To make it easier to maintain the skin CSS, CKEditor makes it possible to define browser specific files, which hold all "hacks" necessary for them. For example, a skin can contain the `editor_ie.c s` file with all IE hacks or `dialog_opera.css` for Opera specific stuff.
+To make it easier to maintain the skin CSS, CKEditor makes it possible to define browser specific files, which hold all "hacks" necessary for them. For example, a skin can contain the `editor_ie.css` file with all IE hacks or `dialog_opera.css` for Opera specific stuff.
 
 A skin must instruct CKEditor to load, for example, `editor_ie.css` instead of `editor.css` on IE browsers. This must be done by setting the `CKEDITOR.skin.ua_editor` value to the list of "browser files" available. The same can be done for `dialog.css`. Check out the `skin.js` file of the [Moono skin](#!/guide/skin_sdk_intro-section-2) for a real example.
 


### PR DESCRIPTION
Fixed a typo in editor_ie.css file name, can be found at http://docs.ckeditor.com/#!/guide/skin_sdk_browser_hacks.