### PR TITLE
Fix missing quote around `width` causing syntax coloring issues

### DIFF
--- a/docs/guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README.md
@@ -182,7 +182,7 @@ Element and property names can also be specified in more variants &mdash; as obj
 
 	allowedContent: {
 		img: {
-			attributes: [ '!src', 'alt', width', 'height' ],
+			attributes: [ '!src', 'alt', 'width', 'height' ],
 			classes: { tip: true }
 		},
 		// $<n> is a rule name - it does not match element names.


### PR DESCRIPTION
Under the Allowed Content Rules - Special Features section at https://docs.ckeditor.com/ckeditor4/latest/guide/dev_allowed_content_rules.html#special-features

The element for width is missing it's beginning quote.

Before:
<img width="834" alt="screen shot 2018-02-23 at 1 35 43 pm" src="https://user-images.githubusercontent.com/636531/36610497-7b172016-189e-11e8-92d2-ac77e05cb8c5.png">

After:
<img width="805" alt="screen shot 2018-02-23 at 1 29 19 pm" src="https://user-images.githubusercontent.com/636531/36610506-82fdd658-189e-11e8-852d-7986934eb7d1.png">