### PR TITLE
Accessibility Checker custom issue type / QF corrections

### DIFF
--- a/docs/guide/dev/integration/a11ychecker/custom_issue_types/README.md
+++ b/docs/guide/dev/integration/a11ychecker/custom_issue_types/README.md
@@ -28,7 +28,7 @@ In order to hook into the process of issue gathering there are a few things to b
 * Registering the {@link guide/dev/features/accessibility_checker/README#what-exactly-are-issues issue type}.
 * Hooking to the `process` event of `editor._.a11ychecker.engine`.
 
-In this guide whenever we refer to the `editor` variable, it is an instance of {@linkapi CKEDITOR.editor}, and when referring to the `a11ychecker` variable, it is a `editor._.a11ychecker` member.
+In this guide whenever we refer to the `editor` variable, it is an instance of {@linkapi CKEDITOR.editor CKEDITOR.editor} type, and when referring to the `a11ychecker` variable, it is a `editor._.a11ychecker` member.
 
 ## Complete Code Snippet
 

--- a/docs/guide/dev/integration/a11ychecker/custom_quick_fixes/README.md
+++ b/docs/guide/dev/integration/a11ychecker/custom_quick_fixes/README.md
@@ -86,7 +86,7 @@ var config = {
                          * Returns the name of the tag that `issue.element` should be converted to.
                          *
                          * @member CKEDITOR.plugins.a11ychecker.ElementReplace.StrongReplace
-                         * @param {Object} formAttributes Form attributes from {@link #fix}.
+                         * @param {Object} formAttributes Form attributes from `fix` method.
                          * @returns {String}
                          */
                         StrongReplace.prototype.getTargetName = function( formAttributes ) {


### PR DESCRIPTION
Some adjustments are needed.

Most importantly I'd like to move code listings to codepen so that reader can execute it and see how it works. Reading such a big block is a PITA, I'll extract it into a separate ticket (#150).
I have already moved this topic,