### PR TITLE
Removed label descriptions and linked directly to GH list

### DIFF
--- a/docs/guide/dev/issues_tracker/README.md
+++ b/docs/guide/dev/issues_tracker/README.md
@@ -50,4 +50,4 @@ Once you log in, you will be ready to [report a CKEditor issue](https://github.c
 
 ### Labels
 
-Description for each label is available at [GitHub label list](https://github.com/ckeditor/ckeditor-dev/labels).
+Each issue is categorised with labels. Refer to the [GitHub label list](https://github.com/ckeditor/ckeditor-dev/labels) for the label descriptions.

--- a/docs/guide/dev/issues_tracker/README.md
+++ b/docs/guide/dev/issues_tracker/README.md
@@ -50,36 +50,4 @@ Once you log in, you will be ready to [report a CKEditor issue](https://github.c
 
 ### Labels
 
-Every issue may be marked with the following labels:
-
-* Status labels &mdash; current issue status:
-    * <span style="background-color:#e6e6e6;padding:0 3px 0 3px">status:confirmed</span> &ndash; An issue confirmed by the development team.
-    * <span style="background-color:#e6e6e6;padding:0 3px 0 3px">status:pending</span> &ndash; More information is needed to proceed with the issue.
-* Type labels &mdash; the type of the issue:
-    * <span style="background-color:#b60205;color:#FFF;padding:0 3px 0 3px">type:bug</span> &ndash; A bug.
-    * <span style="background-color:#1d76db;color:#FFF;padding:0 3px 0 3px">type:feature</span> &ndash; A feature request.
-    * <span style="background-color:#fbca04;padding:0 3px 0 3px">type:task</span>&ndash; Any other issue (refactoring, typo fix, etc).
-    * <span style="background-color:#b60205;color:#FFF;padding:0 3px 0 3px">type:failingtest</span> &ndash; A failing test.
-* Resolution labels &mdash; how and why the issue was resolved:
-    * <span style="background-color:#444444;color:#FFF;padding:0 3px 0 3px">resolution:duplicate</span> &ndash; A duplicate of an already reported issue.
-    * <span style="background-color:#444444;color:#FFF;padding:0 3px 0 3px">resolution:expired</span> &ndash; Issue reporter did not provide enough information to reproduce the issue for at least 2 weeks.
-    * <span style="background-color:#444444;color:#FFF;padding:0 3px 0 3px">resolution:invalid</span> &ndash; Not a valid issue (wrong request type, support requests, etc).
-    * <span style="background-color:#444444;color:#FFF;padding:0 3px 0 3px">resolution:cantreproduce</span> &ndash; A valid bug report that is not reproducible.
-    * <span style="background-color:#444444;color:#FFF;padding:0 3px 0 3px">resolution:upstream</span> &ndash; Issue in the third-party software.
-    * <span style="background-color:#444444;color:#FFF;padding:0 3px 0 3px">resolution:wontfix</span> &ndash; The issue is valid, however, CKSource does not plan to fix it.
-    * If an issue is closed and there is no resolution label, it means that the issue was fixed and merged to the `master` or `major` branch.
-* Browser labels &mdash; for browser-specific bugs:
-    * <span style="background-color:#5319e7;color:#FFF;padding:0 3px 0 3px">browser:NNN</span> &ndash; The issue can only be reproduced in a particular browser.
-* Plugin labels &mdash; for plugin-specific bugs:
-    * <span style="background-color:#fef2c0;color:#000;padding:0 3px 0 3px">plugin:NNN</span> &ndash; The plugin which probably causes the issue.
-* Changelog labels:
-    * <span style="background-color:#fef2c0;color:#000;padding:0 3px 0 3px">changelog:skip</span> &ndash; A changelog entry should not be added for a given issue.
-    * <span style="background-color:#fef2c0;color:#000;padding:0 3px 0 3px">changelog:api</span> &ndash; A changelog entry should be put in the API section of the changelog.
-* Other &mdash; additional information:
-    * <span style="background-color:#34d058;padding:0 3px 0 3px">easy</span> &ndash; Relatively easy to fix. This is a perfect issue if you are willing to {@link guide/dev/contributing_code/README create a Pull Request}.
-    * <span style="background-color:#b60205;color:#FFF;padding:0 3px 0 3px">regression</span> &ndash; This issue is a regression.
-    * <span style="background-color:#aaaaaa;padding:0 3px 0 3px">support</span> &ndash; An issue reported by a commercially licensed client.
-    * <span style="background-color:#34d058;padding:0 3px 0 3px">review:easy</span> &ndash; Pull requests that can be reviewed by a Junior Developer before being reviewed by the Reviewer.
-    * <span style="background-color:#fef2c0;color:#000;padding:0 3px 0 3px">accessibility</span> &ndash; Issue related to accessibility.
-    * <span style="background-color:#c5def5;color:#000;padding:0 3px 0 3px">target:major</span> &ndash; An issue with a significant change (e.g. a new feature, a breaking change) that should be merged into a _major_ branch.
-    * <span style="background-color:#c5def5;color:#000;padding:0 3px 0 3px">target:minor</span> &ndash; An issue with a less significant change (e.g. a bug fix) that can be merged either into a _master_ or _major_ branch.
+Description for each label is available at [GitHub label list](https://github.com/ckeditor/ckeditor-dev/labels).


### PR DESCRIPTION
Once GH added a possibility to provide descriptions for labels, we decided to move label descriptions to GH.