### PR TITLE
Fix iunvalid HTML markup

### DIFF
--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -48,13 +48,13 @@ See the following example:
 
 ``` html
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <title>A Simple Page with CKEditor</title>
         <!-- Make sure the path to CKEditor is correct. -->
-        <script src="../ckeditor.js"/>
-    </meta></head>
+        <script src="../ckeditor.js"></script>
+    </head>
     <body>
         <form>
             <textarea name="editor1" id="editor1" rows="10" cols="80">


### PR DESCRIPTION
There’s no `</meta>` tag and `<script>` is not self-closing. I added a lang-attribute to `<html>` which is recommended but not a must-have.

See issues on https://validator.w3.org with the old markup.