### PR TITLE
Fix HTML and code listing issues

### DIFF
--- a/docs/guide/dev/a11y/README.md
+++ b/docs/guide/dev/a11y/README.md
@@ -86,7 +86,9 @@ The following features support using CKEditor with assistive technologies such a
 
 When the user reaches an editor instance, the screen reader announces it with the following text:
 
-	Rich text editor, editor1, press Alt+0 for help.
+```html
+Rich text editor, editor1, press Alt+0 for help.
+```
 
 The `editor1` part of the text is simply the {@linkapi CKEDITOR.config#title name that has been assigned to the editor instance} by the developer. This is even more useful when you have more than one editor instance on the same page. The website creator should make sure that editor instance names are meaningful, though, to make it really useful for the users.
 

--- a/docs/guide/dev/best_practices/README.md
+++ b/docs/guide/dev/best_practices/README.md
@@ -53,7 +53,9 @@ Changing the {@linkapi CKEDITOR.config#enterMode Enter Mode} setting to `BR` or 
 
 If you do it to control paragraph spacing, you should use stylesheets instead. Edit the `contents.css` file and set up a suitable `margin` value for `<p>` elements, for example:
 
-	p { margin: 0; }
+```css
+p { margin: 0; }
+```
 
 ### Configure Styles drop-down
 If you are using a CKEditor build which includes the Styles drop-down (like Standard or Full), take a few minutes to {@link guide/dev/features/styles/README configure it} after you install the editor.
@@ -85,7 +87,7 @@ Last but not least, {@link guide/dev/basics/README#what-ckeditor-is use CKEditor
 
 ### Filter content server-side
 
-**No editor features (such as {@link guide/dev/acf/README Advanced Content Filter (ACF)} or paste filter) should be treated as security filters.** If the content that is to be loaded into CKEditor comes from untrusted sources (e.g. the users of your website), you should always filter it on the server side to avoid potential XSS issues &mdash; just like you would do it for any other content intended to be published on your website. The same applies to publishing content on your website. Before displaying content on your website coming from untrusted users, regardless whether CKEditor is enabled or not, you should filter the content against XSS. The reason is that malicious users can disable CKEditor in a browser or use software to alter the POST request and send anything. 
+**No editor features (such as {@link guide/dev/acf/README Advanced Content Filter (ACF)} or paste filter) should be treated as security filters.** If the content that is to be loaded into CKEditor comes from untrusted sources (e.g. the users of your website), you should always filter it on the server side to avoid potential XSS issues &mdash; just like you would do it for any other content intended to be published on your website. The same applies to publishing content on your website. Before displaying content on your website coming from untrusted users, regardless whether CKEditor is enabled or not, you should filter the content against XSS. The reason is that malicious users can disable CKEditor in a browser or use software to alter the POST request and send anything.
 
 ### Use ACF in default, automatic mode
 

--- a/docs/guide/dev/build/README.md
+++ b/docs/guide/dev/build/README.md
@@ -38,10 +38,10 @@ Edit the `build-config.js` file which contains the build configuration. It inclu
 var CKBUILDER_CONFIG = {
 	// Skin name.
 	skin: '...',
-	
+
 	// Files to be ignored.
 	ignore: [ ... ],
-	
+
 	// Plugins to be included.
 	plugins: { ... }
 };
@@ -55,7 +55,9 @@ Some plugins might need others to work, but you do not have to resolve these dep
 
 Go to the command line and call the build script:
 
-	./build.sh
+``` sh
+./build.sh
+```
 
 The builder will be executed and the resulting build will be created in the `dev/builder/build` folder.
 
@@ -63,6 +65,6 @@ The builder will be executed and the resulting build will be created in the `dev
 
 The building process is handled by the command line version of [CKBuilder](https://ckeditor.com/cke4/builder). It is a powerful application that makes several enhancements to the source code: it loads the configuration file, resolves plugin dependencies, merges and minifies files, creates icon strips, and performs many other build-related tasks.
 
-For the first run, `build.sh` will need to [download CKBuilder](http://download.cksource.com/CKBuilder/) and copy it into the `dev/builder/ckbuilder/<ckbuilder version="">` folder, so an Internet connection is required. Once the file is available, no more downloads are necessary (though if possible, the script will try to perform an update on consecutive runs).
+For the first run, `build.sh` will need to [download CKBuilder](http://download.cksource.com/CKBuilder/) and copy it into the `dev/builder/ckbuilder/<ckbuilder version>` folder, so an Internet connection is required. Once the file is available, no more downloads are necessary (though if possible, the script will try to perform an update on consecutive runs).
 
 The only requirement to run CKBuilder is [Java](http://www.java.com/en/download/).

--- a/docs/guide/dev/ckeditor_js_load/README.md
+++ b/docs/guide/dev/ckeditor_js_load/README.md
@@ -17,7 +17,7 @@ CKEditor is a JavaScript application. To load it, you need to include a single f
 ``` html
 <head>
     ...
-    <script src="/ckeditor/ckeditor.js"/>
+    <script src="/ckeditor/ckeditor.js"></script>
 </head>
 ```
 

--- a/docs/guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/allowed_content_rules/README.md
@@ -74,45 +74,48 @@ Special characters:
 
 Examples:
 
-	// A rule accepting <p> and <h1> elements, but without any property.
-	p h1
+```js
+// A rule accepting <p> and <h1> elements, but without any property.
+p h1
 
-	// A rule accepting <p> and <h1> elements with optional "left" and "right" classes.
-	// Note: Both elements may contain these classes, not only <h1>.
-	p h1(left,right)
+// A rule accepting <p> and <h1> elements with optional "left" and "right" classes.
+// Note: Both elements may contain these classes, not only <h1>.
+p h1(left,right)
 
-	// A rule accepting <p> and <h1> elements with all their attributes.
-	p h1[*]
+// A rule accepting <p> and <h1> elements with all their attributes.
+p h1[*]
 
-	// A rule accepting <p> and <h1> elements with all their attributes
-	// starting from 'data-'.
-	p h1[data-*]
+// A rule accepting <p> and <h1> elements with all their attributes
+// starting from 'data-'.
+p h1[data-*]
 
-	// A rule accepting <a> only if it contains the "href" attribute.
-	a[!href]
+// A rule accepting <a> only if it contains the "href" attribute.
+a[!href]
 
-	// A rule accepting <img> with a required "src" attribute and an optional
-	// "alt" attribute plus optional "width" and "height" styles.
-	img[alt,!src]{width,height}
+// A rule accepting <img> with a required "src" attribute and an optional
+// "alt" attribute plus optional "width" and "height" styles.
+img[alt,!src]{width,height}
 
-	// The same as above, because the order of properties and their lists is irrelevant and white-spaces are ignored.
-	img { height, width } [ !src, alt ]
+// The same as above, because the order of properties and their lists is irrelevant and white-spaces are ignored.
+img { height, width } [ !src, alt ]
+```
 
 The Allowed Content Rules set may consist of many rules separated by semicolon (`;`) characters. Examples:
 
-	// Rules allowing:
-	// * <p> and <h1> elements with an optional "text-align" style,
-	// * <a> with a required "href" attribute,
-	// * <strong> and <em> elements,
-	// * <p> with an optional "tip" class (so <p> element may contain
-	//	a "text-align" style and a "tip" class at the same time).
-	p h1{text-align}; a[!href]; strong em; p(tip)
+```js
+// Rules allowing:
+// * <p> and <h1> elements with an optional "text-align" style,
+// * <a> with a required "href" attribute,
+// * <strong> and <em> elements,
+// * <p> with an optional "tip" class (so <p> element may contain
+//	a "text-align" style and a "tip" class at the same time).
+p h1{text-align}; a[!href]; strong em; p(tip)
 
-	// Rules allowing:
-	// * <p> and <h1> elements with an optional "id" attribute,
-	// * <a> with a required "href" attribute and an optional "id" attribute.
-	p h1; a[!href]; *[id]
-
+// Rules allowing:
+// * <p> and <h1> elements with an optional "id" attribute,
+// * <a> with a required "href" attribute and an optional "id" attribute.
+p h1; a[!href]; *[id]
+```
 
 ### Debugging
 

--- a/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
@@ -32,31 +32,39 @@ Best to see it in examples.
 
 1. Disallowing entire elements.
 
-		config.allowedContent = 'h1 h2 h3 p';
-		config.disallowedContent = 'h2 h3';
-		// Input:		<h1>Foo</h1><h2>Bar</h2><h3>Bom</h3>
-		// Filtered:	<h1>Foo</h1><p>Bar</p><p>Bom</p>
+```js
+config.allowedContent = 'h1 h2 h3 p';
+config.disallowedContent = 'h2 h3';
+// Input:		<h1>Foo</h1><h2>Bar</h2><h3>Bom</h3>
+// Filtered:	<h1>Foo</h1><p>Bar</p><p>Bom</p>
+```
 
 1. Disallowing attributes, classes, and styles.
 
-		config.allowedContent = 'p[*]{*}(foo,bar)';
-		config.disallowedContent = 'p[on*](foo)';
-		// Input:		<p>Foo</p><p onclick="..." data-foo="1" class="foo bar">Bar</p>
-		// Filtered:	<p>Foo</p><p data-foo="1" class="bar">Bar</p>
+```js
+config.allowedContent = 'p[*]{*}(foo,bar)';
+config.disallowedContent = 'p[on*](foo)';
+// Input:		<p>Foo</p><p onclick="..." data-foo="1" class="foo bar">Bar</p>
+// Filtered:	<p>Foo</p><p data-foo="1" class="bar">Bar</p>
+```
 
 1. Disallowing a required property.
 
-		config.allowedContent = 'p; img[!src,alt]';
-		config.disallowedContent = 'img[src]';
-		// Input:		<p><img src="%BASE_PATH%/assets/img/..." alt="..."/></p>
-		// Filtered:	<p/>
+```js
+config.allowedContent = 'p; img[!src,alt]';
+config.disallowedContent = 'img[src]';
+// Input:		<p><img src="%BASE_PATH%/assets/img/..." alt="..."/></p>
+// Filtered:	<p/>
+```
 
 1. Disallowing properties on all elements.
 
-		config.allowedContent = 'p em{*}';
-		config.disallowedContent = '*{font*}';
-		// Input:		<p style="color: red; font-size: 12px"><em style="font: 'Arial'">Foo</em></p>
-		// Filtered:	<p style="color: red"><em>Foo</em></p>
+```js
+config.allowedContent = 'p em{*}';
+config.disallowedContent = '*{font*}';
+// Input:		<p style="color: red; font-size: 12px"><em style="font: 'Arial'">Foo</em></p>
+// Filtered:	<p style="color: red"><em>Foo</em></p>
+```
 
 1. Tweaking automatically allowed content.
 

--- a/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
@@ -32,44 +32,46 @@ Best to see it in examples.
 
 1. Disallowing entire elements.
 
-```js
-config.allowedContent = 'h1 h2 h3 p';
-config.disallowedContent = 'h2 h3';
-// Input:		<h1>Foo</h1><h2>Bar</h2><h3>Bom</h3>
-// Filtered:	<h1>Foo</h1><p>Bar</p><p>Bom</p>
-```
+	```js
+	config.allowedContent = 'h1 h2 h3 p';
+	config.disallowedContent = 'h2 h3';
+	// Input:		<h1>Foo</h1><h2>Bar</h2><h3>Bom</h3>
+	// Filtered:	<h1>Foo</h1><p>Bar</p><p>Bom</p>
+	```
 
-1. Disallowing attributes, classes, and styles.
+2. Disallowing attributes, classes, and styles.
 
-```js
-config.allowedContent = 'p[*]{*}(foo,bar)';
-config.disallowedContent = 'p[on*](foo)';
-// Input:		<p>Foo</p><p onclick="..." data-foo="1" class="foo bar">Bar</p>
-// Filtered:	<p>Foo</p><p data-foo="1" class="bar">Bar</p>
-```
+	```js
+	config.allowedContent = 'p[*]{*}(foo,bar)';
+	config.disallowedContent = 'p[on*](foo)';
+	// Input:		<p>Foo</p><p onclick="..." data-foo="1" class="foo bar">Bar</p>
+	// Filtered:	<p>Foo</p><p data-foo="1" class="bar">Bar</p>
+	```
 
-1. Disallowing a required property.
+3. Disallowing a required property.
 
-```js
-config.allowedContent = 'p; img[!src,alt]';
-config.disallowedContent = 'img[src]';
-// Input:		<p><img src="%BASE_PATH%/assets/img/..." alt="..."/></p>
-// Filtered:	<p/>
-```
+	```js
+	config.allowedContent = 'p; img[!src,alt]';
+	config.disallowedContent = 'img[src]';
+	// Input:		<p><img src="%BASE_PATH%/assets/img/..." alt="..."/></p>
+	// Filtered:	<p/>
+	```
 
-1. Disallowing properties on all elements.
+4. Disallowing properties on all elements.
 
-```js
-config.allowedContent = 'p em{*}';
-config.disallowedContent = '*{font*}';
-// Input:		<p style="color: red; font-size: 12px"><em style="font: 'Arial'">Foo</em></p>
-// Filtered:	<p style="color: red"><em>Foo</em></p>
-```
+	```js
+	config.allowedContent = 'p em{*}';
+	config.disallowedContent = '*{font*}';
+	// Input:		<p style="color: red; font-size: 12px"><em style="font: 'Arial'">Foo</em></p>
+	// Filtered:	<p style="color: red"><em>Foo</em></p>
+	```
 
-1. Tweaking automatically allowed content.
+5. Tweaking automatically allowed content.
 
-		// Enabled plugins: image and table.
-		config.disallowedContent = 'img{border*,margin*}; table[border]{*}';
+	```js
+	// Enabled plugins: image and table.
+	config.disallowedContent = 'img{border*,margin*}; table[border]{*}';
+	```
 
     With this code implemented, open the Image Properties dialog window and see that the Border, HSpace, and VSpace fields were hidden. You can also open the Table dialog window and see that the Border, Width, and Height fields were hidden, too.
 

--- a/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
+++ b/docs/guide/dev/deep_dive/advanced_content_filter/disallowed_content/README.md
@@ -35,8 +35,8 @@ Best to see it in examples.
 	```js
 	config.allowedContent = 'h1 h2 h3 p';
 	config.disallowedContent = 'h2 h3';
-	// Input:		<h1>Foo</h1><h2>Bar</h2><h3>Bom</h3>
-	// Filtered:	<h1>Foo</h1><p>Bar</p><p>Bom</p>
+	// Input:    <h1>Foo</h1><h2>Bar</h2><h3>Bom</h3>
+	// Filtered: <h1>Foo</h1><p>Bar</p><p>Bom</p>
 	```
 
 2. Disallowing attributes, classes, and styles.
@@ -44,8 +44,8 @@ Best to see it in examples.
 	```js
 	config.allowedContent = 'p[*]{*}(foo,bar)';
 	config.disallowedContent = 'p[on*](foo)';
-	// Input:		<p>Foo</p><p onclick="..." data-foo="1" class="foo bar">Bar</p>
-	// Filtered:	<p>Foo</p><p data-foo="1" class="bar">Bar</p>
+	// Input:    <p>Foo</p><p onclick="..." data-foo="1" class="foo bar">Bar</p>
+	// Filtered: <p>Foo</p><p data-foo="1" class="bar">Bar</p>
 	```
 
 3. Disallowing a required property.
@@ -53,8 +53,8 @@ Best to see it in examples.
 	```js
 	config.allowedContent = 'p; img[!src,alt]';
 	config.disallowedContent = 'img[src]';
-	// Input:		<p><img src="%BASE_PATH%/assets/img/..." alt="..."/></p>
-	// Filtered:	<p/>
+	// Input:    <p><img src="%BASE_PATH%/assets/img/..." alt="..."/></p>
+	// Filtered: <p/>
 	```
 
 4. Disallowing properties on all elements.
@@ -62,8 +62,8 @@ Best to see it in examples.
 	```js
 	config.allowedContent = 'p em{*}';
 	config.disallowedContent = '*{font*}';
-	// Input:		<p style="color: red; font-size: 12px"><em style="font: 'Arial'">Foo</em></p>
-	// Filtered:	<p style="color: red"><em>Foo</em></p>
+	// Input:    <p style="color: red; font-size: 12px"><em style="font: 'Arial'">Foo</em></p>
+	// Filtered: <p style="color: red"><em>Foo</em></p>
 	```
 
 5. Tweaking automatically allowed content.

--- a/docs/guide/dev/deep_dive/unsupported_environments/README.md
+++ b/docs/guide/dev/deep_dive/unsupported_environments/README.md
@@ -44,7 +44,7 @@ In CKEditor 4.5 and beyond, the {@linkapi CKEDITOR.env.isCompatible CKEDITOR.env
 
 This flag is checked only in functions creating an editor instance, like {@linkapi CKEDITOR.replace CKEDITOR.replace}, {@linkapi CKEDITOR.inline CKEDITOR.inline}, or {@linkapi CKEDITOR.appendTo CKEDITOR.appendTo} This means that the flag can be modified before creating an editor instance, but after the `<script>` tag that adds the CKEditor script to the page. For example:
 
-	<script src="ckeditor/ckeditor.js"/>
+	<script src="ckeditor/ckeditor.js"></script>
 	<script>
 		CKEDITOR.env.isCompatible = true;
 	</script>
@@ -52,7 +52,7 @@ This flag is checked only in functions creating an editor instance, like {@linka
 
 Or even later, when creating an instance:
 
-	<textarea id="editor1" ...=""/>
+	<textarea id="editor1" ...></textarea>
 	<script>
 		CKEDITOR.env.isCompatible = true;
 		CKEDITOR.replace( 'editor1' );

--- a/docs/guide/dev/example_setups/README.md
+++ b/docs/guide/dev/example_setups/README.md
@@ -152,4 +152,3 @@ Refer to the {@link guide/dev/plugins/README#through-ckbuilder Installing Plugin
 <tr><th>Number of files requested by the browser</th><td>Low</td><td>Plugins are bundled into a single <code>ckeditor.js</code> file. Icons are merged into a sprite. Language files are merged.</td></tr>
 <tr><th>Performance</th><td>High</td><td>The only problem might be in slow networks where CKEditor is hosted and/or in a misconfigured server without file compression enabled. Such setup would influence not only CKEditor but would also slow down the whole web application.</td></tr>
 </table>
-</iframe>

--- a/docs/guide/dev/features/autogrow/README.md
+++ b/docs/guide/dev/features/autogrow/README.md
@@ -57,7 +57,9 @@ This will ensure no page redrawing will be needed &mdash; until you start modify
 
 An additional {@linkapi CKEDITOR.config.autoGrow_bottomSpace CKEDITOR.config.autoGrow_bottomSpace} option lets you insert some extra space that will always be added between the content and the editor bottom bar. For example, you can set it to 50 pixels in order to prevent the editor from looking too cramped.
 
-    config.autoGrow_bottomSpace = 50;
+```js
+config.autoGrow_bottomSpace = 50;
+```
 
 With this setting in place, the 50-pixel-high space below the content will always be preserved. This is visible in the sample as well as the second image above.
 

--- a/docs/guide/dev/features/codesnippet/README.md
+++ b/docs/guide/dev/features/codesnippet/README.md
@@ -31,7 +31,7 @@ If you use the {@link guide/dev/inline/README inline} or [div-based](https://cke
 ``` html
 <head>
     ...
-    <link href="ckeditor/plugins/codesnippet/lib/highlight/styles/default.css" rel="stylesheet"/>
+    <link href="ckeditor/plugins/codesnippet/lib/highlight/styles/default.css" rel="stylesheet">
 </head>
 ```
 
@@ -48,8 +48,8 @@ Attach it to the `<head>` section of your page. The following code will load the
 ``` html
 <head>
     ...
-    <link href="ckeditor/plugins/codesnippet/lib/highlight/styles/default.css" rel="stylesheet"/>
-    <script src="ckeditor/plugins/codesnippet/lib/highlight/highlight.pack.js"/>
+    <link href="ckeditor/plugins/codesnippet/lib/highlight/styles/default.css" rel="stylesheet">
+    <script src="ckeditor/plugins/codesnippet/lib/highlight/highlight.pack.js"></script>
 </head>
 ```
 
@@ -82,7 +82,7 @@ You can customize the list of languages with syntax highlighting support by sett
 
 The following example will reduce the languages list to JavaScript and PHP only.
 
-```
+```js
 config.codeSnippet_languages = {
     javascript: 'JavaScript',
     php: 'PHP'

--- a/docs/guide/dev/features/codesnippetgeshi/README.md
+++ b/docs/guide/dev/features/codesnippetgeshi/README.md
@@ -40,18 +40,18 @@ First of all you need to add both the Code Snippet GeSHi plugin and its dependen
 
     ``` php
     <?php
-    
+
     if ( function_exists( 'stream_resolve_include_path' ) && stream_resolve_include_path( 'geshi/geshi.php' ) === FALSE ) {
         die( '<pre class="html">Please install the GeSHi library. Refer to plugins/codesnippetgeshi/README.md for more information.' );
     }
-    
+
     include_once 'geshi/geshi.php';
-    
+
     $json_string = file_get_contents( 'php://input' );
     $json_object = json_decode( $json_string );
-    
+
     $geshi = new GeSHi( $json_object->html, $json_object->lang );
-    
+
     echo $geshi->parse_code();
     ```
 
@@ -62,11 +62,11 @@ First of all you need to add both the Code Snippet GeSHi plugin and its dependen
     ```
     lib/
         geshi/
-            <GeSHi directories...="">
+            <GeSHi directories...>
             geshi.php
         colorize.php
     ckeditor/
-        <CKEditor files="" and="" directories...="">
+        <CKEditor files and directories>
         ckeditor.js
     ```
 

--- a/docs/guide/dev/features/embed/README.md
+++ b/docs/guide/dev/features/embed/README.md
@@ -33,7 +33,7 @@ Media Embed:
 			<p>Coding session with <a href="https://twitter.com/fredck">@fredck</a>, <a href="https://twitter.com/anowodzinski">@anowodzinski</a> and Mr Carrot. <a href="http://t.co/FLV5UXpfaT">pic.twitter.com/FLV5UXpfaT</a></p>
 			&mdash; Piotrek Koszuliński (@reinmarpl) <a href="https://twitter.com/reinmarpl/status/573118615274315776">March 4, 2015</a>
 		</blockquote>
-		<script async charset="utf-8" src="//platform.twitter.com/widgets.js"/>
+		<script async charset="utf-8" src="//platform.twitter.com/widgets.js"></script>
 	</div>
 
 Semantic Media Embed:

--- a/docs/guide/dev/features/fullpage/README.md
+++ b/docs/guide/dev/features/fullpage/README.md
@@ -35,9 +35,11 @@ With these settings in place, CKEditor will output the entire HTML page, includi
  <p>
  Since in full page mode you usually want to be able to freely enter any HTML content without limitations, default editor {@link guide/dev/acf/README content filtering} can be disabled to prevent CKEditor from removing disallowed elements.
  </p>
-<pre>
+
+```js
 config.allowedContent = true;
-</pre>
+```
+
 </info-box>
 
 The following image shows the source of a complete HTML page edited in CKEditor.

--- a/docs/guide/dev/features/mathjax/README.md
+++ b/docs/guide/dev/features/mathjax/README.md
@@ -45,7 +45,7 @@ You can also use a different path, either a local resource or a different web re
 In order to display mathematical formulas on a target page, i.e. the page where content produced by CKEditor will be visible, the target page needs to [include the MathJax script](http://docs.mathjax.org/en/latest/start.html). It is advisable to use the same MathJax library version as set in the {@linkapi CKEDITOR.config.mathJaxLib CKEDITOR.config.mathJaxLib} configuration option. For example for the default setting this would be:
 
 ``` html
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML"/>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML"></script>
 ```
 
 ## Changing Default Class

--- a/docs/guide/dev/features/output_format/README.md
+++ b/docs/guide/dev/features/output_format/README.md
@@ -27,34 +27,36 @@ The current writer for a specific editor instance can be retrieved with the {@li
 It is possible to configure several output formatting options by setting
 the writer properties. The following example summarizes the most common properties and gives their default values:
 
-	var writer = editor.dataProcessor.writer;
+```js
+var writer = editor.dataProcessor.writer;
 
-	// The character sequence to use for every indentation step.
-	writer.indentationChars = '\t';
+// The character sequence to use for every indentation step.
+writer.indentationChars = '\t';
 
-	// The way to close self-closing tags, like <br/>.
-	writer.selfClosingEnd = ' />';
+// The way to close self-closing tags, like <br/>.
+writer.selfClosingEnd = ' />';
 
-	// The character sequence to be used for line breaks.
-	writer.lineBreakChars = '\n';
+// The character sequence to be used for line breaks.
+writer.lineBreakChars = '\n';
 
-	// The writing rules for the <p> tag.
-	writer.setRules( 'p', {
-		// Indicates that this tag causes indentation on line breaks inside of it.
-		indent: true,
+// The writing rules for the <p> tag.
+writer.setRules( 'p', {
+	// Indicates that this tag causes indentation on line breaks inside of it.
+	indent: true,
 
-		// Inserts a line break before the <p> opening tag.
-		breakBeforeOpen: true,
+	// Inserts a line break before the <p> opening tag.
+	breakBeforeOpen: true,
 
-		// Inserts a line break after the <p> opening tag.
-		breakAfterOpen: true,
+	// Inserts a line break after the <p> opening tag.
+	breakAfterOpen: true,
 
-		// Inserts a line break before the </p> closing tag.
-		breakBeforeClose: false,
+	// Inserts a line break before the </p> closing tag.
+	breakBeforeClose: false,
 
-		// Inserts a line break after the </p> closing tag.
-		breakAfterClose: true
-	});
+	// Inserts a line break after the </p> closing tag.
+	breakAfterClose: true
+} );
+```
 
 ## Setting Writer Rules
 
@@ -65,20 +67,22 @@ event, so it is safe to assume that the {@linkapi CKEDITOR.editor#dataProcessor 
 loaded and ready for changes. The following code shows an example of
 this approach used when creating an editor instance:
 
-	CKEDITOR.replace( 'editor1', {
-		on: {
-			instanceReady: function( ev ) {
-				// Output paragraphs as <p>Text</p>.
-				this.dataProcessor.writer.setRules( 'p', {
-					indent: false,
-					breakBeforeOpen: true,
-					breakAfterOpen: false,
-					breakBeforeClose: false,
-					breakAfterClose: true
-				});
-			}
+```js
+CKEDITOR.replace( 'editor1', {
+	on: {
+		instanceReady: function( ev ) {
+			// Output paragraphs as <p>Text</p>.
+			this.dataProcessor.writer.setRules( 'p', {
+				indent: false,
+				breakBeforeOpen: true,
+				breakAfterOpen: false,
+				breakBeforeClose: false,
+				breakAfterClose: true
+			});
 		}
-	});
+	}
+} );
+```
 
 Another solution is to use the {@linkapi CKEDITOR } object which will cause all editor instances to be changed:
 

--- a/docs/guide/dev/features/resize/README.md
+++ b/docs/guide/dev/features/resize/README.md
@@ -60,14 +60,17 @@ It is also possible to define the minimum and maximum dimensions after resizing 
 
 To define the minimum editor dimensions after resizing, specify the {@linkapi CKEDITOR.config.resize_minWidth CKEDITOR.config.resize_minWidth} and {@linkapi CKEDITOR.config.resize_minHeight CKEDITOR.config.resize_minHeight} values in pixels.
 
-	config.resize_minWidth = 300;
-	config.resize_minHeight = 300;
+```js
+config.resize_minWidth = 300;
+config.resize_minHeight = 300;
+```
 
 To define the maximum editor dimensions after resizing, specify the {@linkapi CKEDITOR.config.resize_maxWidth CKEDITOR.config.resize_maxWidth} and {@linkapi CKEDITOR.config.resize_maxHeight CKEDITOR.config.resize_maxHeight} values in pixels.
 
-	config.resize_maxWidth = 800;
-	config.resize_maxHeight = 600;
-
+```js
+config.resize_maxWidth = 800;
+config.resize_maxHeight = 600;
+```
 
 ## Limiting the Resizing Directions
 

--- a/docs/guide/dev/features/sharedspace/README.md
+++ b/docs/guide/dev/features/sharedspace/README.md
@@ -58,9 +58,9 @@ The Shared Space feature affects a crucial editor element &mdash; its user inter
 * The [Editor Resize](https://ckeditor.com/cke4/addon/resize) plugin should be disabled as it would not work in this context.
 * Since CKEditor 4.5.5 the [Maximize](https://ckeditor.com/cke4/addon/maximize) plugin is disabled automatically in the shared space context.
 
-<pre>
+```js
 config.removePlugins = 'resize';
-</pre>
+```
 
 ## Shared Toolbar and Bottom Bar Demo
 

--- a/docs/guide/dev/features/sourcearea/README.md
+++ b/docs/guide/dev/features/sourcearea/README.md
@@ -60,7 +60,9 @@ If another plugin generates CKEditor output data format other than HTML, like fo
 At the moment the only aspect of the source code view that you can configure is the `tab-size` CSS property of the source editing area. Use the {@linkapi CKEDITOR.config.sourceAreaTabSize CKEDITOR.config.sourceAreaTabSize} option to set the width of the tab character. Enter an integer
 to denote the number of spaces that the tab will contain.
 
-	config.sourceAreaTabSize = 8;
+```js
+config.sourceAreaTabSize = 8;
+```
 
 Please note this is an experimental CSS property which may not be supported in all web browsers.
 

--- a/docs/guide/dev/features/styles/README.md
+++ b/docs/guide/dev/features/styles/README.md
@@ -72,7 +72,7 @@ The entries inside a style definition are called *the style rules*. Each rule de
 			'css-style1': 'desired value',
 			'css-style2': 'desired value',
 			...
-		}
+		},
 		attributes: {
 			'attribute-name1': 'desired value',
 			'attribute-name2': 'desired value',
@@ -106,18 +106,20 @@ Since widgets are a lot more complex structures than standard content, only clas
 
 Sample widget styles:
 
-	// Enhanced Image (https://ckeditor.com/cke4/addon/image2) style.
-	{ name: 'Banner', type: 'widget', widget: 'image', attributes: { 'class': 'bigBanner' } }
+```js
+// Enhanced Image (https://ckeditor.com/cke4/addon/image2) style.
+{ name: 'Banner', type: 'widget', widget: 'image', attributes: { 'class': 'bigBanner' } }
 
-	// Code Snippet (https://ckeditor.com/cke4/addon/codesnippet) style.
-	{ name: 'Narrow Code', type: 'widget', widget: 'codeSnippet', attributes: { 'class': 'pulledSnippet narrow' } }
+// Code Snippet (https://ckeditor.com/cke4/addon/codesnippet) style.
+{ name: 'Narrow Code', type: 'widget', widget: 'codeSnippet', attributes: { 'class': 'pulledSnippet narrow' } }
 
-	// Media Embed (https://ckeditor.com/cke4/addon/embed) styles.
-	{ name: '240p', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-240p' }, group: 'size' },
-	{ name: '360p', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-360p' }, group: 'size' },
-	{ name: '480p', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-480p' }, group: 'size' },
-	{ name: 'left', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-left' }, group: 'alignment' },
-	{ name: 'thumb', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-thumb' }, group: [ 'size', 'alignment' ] }
+// Media Embed (https://ckeditor.com/cke4/addon/embed) styles.
+{ name: '240p', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-240p' }, group: 'size' },
+{ name: '360p', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-360p' }, group: 'size' },
+{ name: '480p', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-480p' }, group: 'size' },
+{ name: 'left', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-left' }, group: 'alignment' },
+{ name: 'thumb', type: 'widget', widget: 'embed', attributes: { 'class': 'embed-thumb' }, group: [ 'size', 'alignment' ] }
+```
 
 To see how this works in practice, refer to the [Widget Styles](https://sdk.ckeditor.com/samples/styles.html#widget-styles) sample. It contains a working editor instance that includes the {@link guide/dev/features/image2/README enhanced image}, {@link guide/dev/features/embed/README embedded media resources} and {@link guide/dev/features/mathjax/README mathematical formulas} widgets with additional styling.
 
@@ -149,16 +151,20 @@ This solution lets you configure the editor to use existing CSS stylesheet rules
 
 The Stylesheet Parser plugin can be fine-tuned to only take into account the CSS selectors that match the {@linkapi CKEDITOR.config.stylesheetParser_validSelectors CKEDITOR.config.stylesheetParser_validSelectors} configuration value. The default regular expression accepts all CSS rules in a form of `element.class`, but you can modify it to refer to a limited set of elements, like in the example below.
 
-	// Only add rules for <p> and <span> elements.
-	config.stylesheetParser_validSelectors = /\^(p|span)\.\w+/;
+```js
+// Only add rules for <p> and <span> elements.
+config.stylesheetParser_validSelectors = /\^(p|span)\.\w+/;
+```
 
 ### Limiting the CSS Selectors
 
 You can also further customize the Stylesheet Parser plugin by setting the {@linkapi CKEDITOR.config.stylesheetParser_skipSelectors CKEDITOR.config.stylesheetParser_skipSelectors} configuration value. The plugin will then ignore the CSS rules that match the regular expression and will not display them in the **Styles** drop-down list nor use them to output the document content. The default value excludes all rules for the `<body>` element as well as classes defined for no specific element, but you can modify it to ignore a wider set of elements, like in the example below.
 
-	// Ignore rules for <body> and <caption> elements, classes starting with "high",
-	// and any class defined for no specific element.
-	config.stylesheetParser_skipSelectors = /(^body\.|^caption\.|\.high|^\.)/i;
+```js
+// Ignore rules for <body> and <caption> elements, classes starting with "high",
+// and any class defined for no specific element.
+config.stylesheetParser_skipSelectors = /(^body\.|^caption\.|\.high|^\.)/i;
+```
 
 ## Editor Styles Demo
 

--- a/docs/guide/dev/features/uicolor/README.md
+++ b/docs/guide/dev/features/uicolor/README.md
@@ -21,7 +21,9 @@ If you want to change the default UI color, you need to define the {@linkapi CKE
 
 For example, to change the CKEditor UI to the joyful green color that would match this article's header, you could set the following {@link guide/dev/configuration/README editor configuration}:
 
-	config.uiColor = #66AB16;
+```js
+config.uiColor = '#66AB16';
+```
 
 This will cause the editor UI to assume the provided color, as visible below.
 

--- a/docs/guide/dev/features/uitypes/README.md
+++ b/docs/guide/dev/features/uitypes/README.md
@@ -55,9 +55,9 @@ In floating UI, used by default in inline editor:
 * The toolbar location changes dynamically to ensure that the toolbar is always available.
 * The size of the editing area is determined by the size of the content inside.
 
-<p class="note">
+<info-box info="">
 	Floating UI is not available for classic editor.
-</p>
+</info-box>
 
 If you open a page that contains an inline editor instance you will see that the toolbar is shown on demand and it moves dynamically on the page adjusting itself to the viewport and a page element that is focused.
 

--- a/docs/guide/dev/framed/README.md
+++ b/docs/guide/dev/framed/README.md
@@ -70,11 +70,11 @@ To insert a CKEditor instance, you can use the following sample that creates a b
 
 ``` html
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>CKEditor Classic Editing Sample</title>
     <!-- Make sure the path to CKEditor is correct. -->
-    <script src="/ckeditor/ckeditor.js"/>
+    <script src="/ckeditor/ckeditor.js"></script>
 </head>
 <body>
     <form method="post">
@@ -84,10 +84,10 @@ To insert a CKEditor instance, you can use the following sample that creates a b
             <script>
                 {@linkapi CKEDITOR.replace CKEDITOR.replace}( 'editor1' );
             </script>
-        </br></p>
+        </p>
         <p>
             <input type="submit">
-        </input></p>
+		</p>
     </form>
 </body>
 </html>

--- a/docs/guide/dev/howtos/dialog_windows/README.md
+++ b/docs/guide/dev/howtos/dialog_windows/README.md
@@ -23,20 +23,22 @@ CKEditor allows you to customize dialog windows without changing the original ed
 
 In order to assign a default value to a dialog window field, use the `'default'` parameter in the dialog window {@linkapi CKEDITOR.dialog.definition.uiElement UI element definition}.
 
-	elements: [
-		{
-			type: 'text',
-			id: 'myCustomField',
-			label: 'My Custom Field',
-			'default': 'Default custom field value.'
-		},
-		{
-			type: 'checkbox',
-			id: 'myCheckbox',
-			label: 'This checkbox is selected by default.',
-			'default': true
-		}
-	]
+```js
+elements: [
+	{
+		type: 'text',
+		id: 'myCustomField',
+		label: 'My Custom Field',
+		'default': 'Default custom field value.'
+	},
+	{
+		type: 'checkbox',
+		id: 'myCheckbox',
+		label: 'This checkbox is selected by default.',
+		'default': true
+	}
+]
+```
 
 The code above creates the following UI elements in a sample dialog window tab.
 
@@ -112,13 +114,13 @@ CKEditor dialog windows can be resized by using the resizing grip located in the
 
 {@img assets/img/howtos_captionedimage_03.png The resizing grip of a CKEditor dialog window}
 
-You can disable the resizing feature completely by setting the {@linkapi CKEDITOR.dialog.definition#resizable resizable} parameter to  CKEDITOR#DIALOG_RESIZE_NONE.
+You can disable the resizing feature completely by setting the {@linkapi CKEDITOR.dialog.definition#resizable resizable} parameter to  {@linkapi CKEDITOR#DIALOG_RESIZE_NONE}.
 
 	{@linkapi CKEDITOR.on CKEDITOR.on}( 'dialogDefinition', function( ev ) {
 		ev.data.definition.resizable = {@linkapi CKEDITOR.DIALOG_RESIZE_NONE CKEDITOR.DIALOG_RESIZE_NONE};
 	});
 
-Use the CKEDITOR#DIALOG_RESIZE_WIDTH and CKEDITOR#DIALOG_RESIZE_HEIGHT values to enable resizing of a dialog window in one dimension only.
+Use the {@linkapi CKEDITOR#DIALOG_RESIZE_WIDTH} and {@linkapi CKEDITOR#DIALOG_RESIZE_HEIGHT} values to enable resizing of a dialog window in one dimension only.
 
 
 ## How Do I Remove the Ability to Resize Specific CKEditor Dialog Windows?
@@ -132,4 +134,4 @@ If you want to leave the resizing feature for some of the dialog windows and tur
 			ev.data.definition.resizable = {@linkapi CKEDITOR.DIALOG_RESIZE_HEIGHT CKEDITOR.DIALOG_RESIZE_HEIGHT};
 	});
 
-Use the CKEDITOR#DIALOG_RESIZE_WIDTH and CKEDITOR#DIALOG_RESIZE_HEIGHT values to enable resizing of a dialog window in one dimension only.
+Use the {@linkapi CKEDITOR#DIALOG_RESIZE_WIDTH} and {@linkapi CKEDITOR#DIALOG_RESIZE_HEIGHT} values to enable resizing of a dialog window in one dimension only.

--- a/docs/guide/dev/howtos/scayt/README.md
+++ b/docs/guide/dev/howtos/scayt/README.md
@@ -40,4 +40,4 @@ By default {@link guide/dev/features/spellcheck/README#spell-check-as-you-type-%
 	// Sets SCAYT to French.
 	config.scayt_sLang = 'fr_FR';
 
-The following language codes are currently supported by SCAYT: `en_US, en_GB, pt_BR, da_DK, nl_NL, en_CA, fi_FI, fr_FR, fr_CA, de_DE, el_GR, it_IT, nb_NO, pt_PT, es_ES, and sv_SE`. If you enter a language code that is not supported, SCAYT will fall back to the default American English setting.
+The following language codes are currently supported by SCAYT: `en_US`, `en_GB`, `pt_BR`, `da_DK`, `nl_NL`, `en_CA`, `fi_FI`, `fr_FR`, `fr_CA`, `de_DE`, `el_GR`, `it_IT`, `nb_NO`, `pt_PT`, `es_ES`, and `sv_SE`. If you enter a language code that is not supported, SCAYT will fall back to the default American English setting.

--- a/docs/guide/dev/howtos/styles/README.md
+++ b/docs/guide/dev/howtos/styles/README.md
@@ -60,11 +60,13 @@ Add a style definition as described in the {@link guide/dev/howtos/styles/README
 
 The following example adds the `myClass` class to an `<img>` element. The image element will now be styled as defined in this CSS class.
 
-	{
-		name: 'Custom Image',
-		element: 'img',
-		attributes: { 'class': 'myClass' }
-	}
+```js
+{
+	name: 'Custom Image',
+	element: 'img',
+	attributes: { 'class': 'myClass' }
+}
+```
 
 For more details on the definition format and best practices on how to customize the styles please refer to the {@link guide/dev/features/styles/README Applying Styles to Editor Content} article.
 

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -48,13 +48,13 @@ See the following example:
 
 ``` html
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <title>A Simple Page with CKEditor</title>
         <!-- Make sure the path to CKEditor is correct. -->
-        <script src="../ckeditor.js"/>
-    </meta></head>
+        <script src="../ckeditor.js"></script>
+    </head>
     <body>
         <form>
             <textarea name="editor1" id="editor1" rows="10" cols="80">

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -46,7 +46,7 @@ To start, create a simple HTML page with a `<textarea>` element in it. You will 
 
 See the following example:
 
-``` html
+```html
 <!DOCTYPE html>
 <html lang="en">
     <head>

--- a/docs/guide/dev/integration/file_browse_upload/dialog_add_file_browser/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/dialog_add_file_browser/README.md
@@ -32,14 +32,16 @@ The [File Browser](https://ckeditor.com/cke4/addon/filebrowser) plugin is built-
 
 To assign the File Browser plugin to an element inside a dialog window, set the `filebrowser` property. For example in the [Image plugin dialog window source](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/image/dialogs/image.js) you can find the following code:
 
-	{
-		type: 'button',
-		id: 'browse',
-		// ...
-		label: editor.lang.common.browseServer,
-		hidden: true,
-		filebrowser: 'info:txtUrl'
-	},
+```js
+{
+	type: 'button',
+	id: 'browse',
+	// ...
+	label: editor.lang.common.browseServer,
+	hidden: true,
+	filebrowser: 'info:txtUrl'
+},
+```
 
 This button will be hidden by default (`hidden:true`). The File Browser plugin looks for all elements with the `filebrowser` attribute and unveils them if an appropriate configuration setting is available ({@link guide/dev/integration/file_browse_upload/README#basic-configuration `filebrowserBrowseUrl`/`filebrowserUploadUrl`}).
 
@@ -53,26 +55,28 @@ The `'info:txtUrl'` value instructs the plugin to update an element with the ID 
 
 Again, to see how file uploads can be handled in a dialog window, the following working example from CKEditor will be used. In the [Image plugin dialog window source](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/image/dialogs/image.js) you can find the following definition of the `Upload` tab:
 
-	{
-		id: 'Upload',
-		hidden: true,
-		filebrowser: 'uploadButton',
-		label: editor.lang.image.upload,
-		elements: [ {
-			type: 'file',
-			id: 'upload',
-			label: editor.lang.image.btnUpload,
-			style: 'height:40px',
-			size: 38
-		},
-		{
-			type: 'fileButton',
-			id: 'uploadButton',
-			filebrowser: 'info:txtUrl',
-			label: editor.lang.image.btnUpload,
-			'for': [ 'Upload', 'upload' ]
-		} ]
+```js
+{
+	id: 'Upload',
+	hidden: true,
+	filebrowser: 'uploadButton',
+	label: editor.lang.image.upload,
+	elements: [ {
+		type: 'file',
+		id: 'upload',
+		label: editor.lang.image.btnUpload,
+		style: 'height:40px',
+		size: 38
 	},
+	{
+		type: 'fileButton',
+		id: 'uploadButton',
+		filebrowser: 'info:txtUrl',
+		label: editor.lang.image.btnUpload,
+		'for': [ 'Upload', 'upload' ]
+	} ]
+},
+```
 
 This example is slightly more complicated than the previous one, because:
 
@@ -91,28 +95,30 @@ The `'for': [ 'Upload', 'upload'   ]` line is used to connect `fileButton` with 
 
 It is possible to define your own function that will be called when a file is selected/uploaded.
 
-	{
-		type: 'button',
-		hidden: true,
-		id: 'id0',
-		label: editor.lang.common.browseServer,
-		filebrowser: {
-			action: 'Browse',
-			// target: 'tab1:id1',
-			onSelect: function( fileUrl, data ) {
-				alert( 'The selected file URL is "' + fileUrl + '"' );
+```js
+{
+	type: 'button',
+	hidden: true,
+	id: 'id0',
+	label: editor.lang.common.browseServer,
+	filebrowser: {
+		action: 'Browse',
+		// target: 'tab1:id1',
+		onSelect: function( fileUrl, data ) {
+			alert( 'The selected file URL is "' + fileUrl + '"' );
 
-				for ( var _info in data )
-					alert( 'data[ "' + _info + '" ]' + ' = ' + data[ _info ] );
+			for ( var _info in data )
+				alert( 'data[ "' + _info + '" ]' + ' = ' + data[ _info ] );
 
-				var dialog = this.getDialog();
-				dialog.getContentElement( 'tab1', 'id1' ).setValue( data[ 'fileUrl' ] );
+			var dialog = this.getDialog();
+			dialog.getContentElement( 'tab1', 'id1' ).setValue( data[ 'fileUrl' ] );
 
-				// Do not call the built-in onSelect command.
-				return false;
-			}
+			// Do not call the built-in onSelect command.
+			return false;
 		}
 	}
+}
+```
 
 In this example the action is set to `'Browse'` in order to call the file manager when the button is clicked. Setting `'target'` is not required, because the target element will be updated in the custom `onSelect` function.
 
@@ -122,28 +128,30 @@ As explained in the {@link guide/dev/integration/file_browse_upload/file_browser
 
 In a similar way that a button can be configured to open the file manager, you can also configure the file button.
 
-	{
-		type: 'file',
-		label: editor.lang.common.upload,
-		labelLayout: 'vertical',
-		id: 'id2'
+```js
+{
+	type: 'file',
+	label: editor.lang.common.upload,
+	labelLayout: 'vertical',
+	id: 'id2'
+},
+{
+	type: 'fileButton',
+	label: editor.lang.common.uploadSubmit,
+	id: 'id3',
+	filebrowser: {
+		action: 'QuickUpload',
+		params: { type: 'Files', currentFolder: '/folder/' },
+		target: 'tab1:id1',
+		onSelect: function( fileUrl, errorMessage ) {
+			alert( 'The url of uploaded file is: ' + fileUrl + '\nerrorMessage: ' + errorMessage );
+			// Do not call the built-in onSelect command.
+			// return false;
+		}
 	},
-	{
-		type: 'fileButton',
-		label: editor.lang.common.uploadSubmit,
-		id: 'id3',
-		filebrowser: {
-			action: 'QuickUpload',
-			params: { type: 'Files', currentFolder: '/folder/' },
-			target: 'tab1:id1',
-			onSelect: function( fileUrl, errorMessage ) {
-				alert( 'The url of uploaded file is: ' + fileUrl + '\nerrorMessage: ' + errorMessage );
-				// Do not call the built-in onSelect command.
-				// return false;
-			}
-		},
-		'for': [ 'tab1', 'id2' ]
-	}
+	'for': [ 'tab1', 'id2' ]
+}
+```
 
 Additional arguments to be passed in the query string to the external file manager can be added in the `filebrowser.params` attribute.
 

--- a/docs/guide/dev/integration/file_browse_upload/file_browser_api/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/file_browser_api/README.md
@@ -90,7 +90,7 @@ The following example shows how to send the URL from a file manager using JavaSc
             window.close();
         }
     </script>
-</meta></head>
+</head>
 <body>
     <button onclick="returnFileUrl()">Select File</button>
 </body>
@@ -140,7 +140,7 @@ Suppose that apart from passing the `fileUrl` value that is assigned to an appro
             window.close();
         }
     </script>
-</meta></head>
+</head>
 <body>
     <button onclick="returnFileUrl()">Select File</button>
 </body>
@@ -151,13 +151,13 @@ Suppose that apart from passing the `fileUrl` value that is assigned to an appro
 
 The following code shows how to send back the URL of an uploaded file from the PHP connector (save it as `upload.php`):
 
-``` html
+```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Example: File Upload</title>
-</meta></head>
+</head>
 <body>
 <?php
 // Required: anonymous function reference number as explained above.
@@ -175,7 +175,7 @@ $url = '/path/to/uploaded/file.ext';
 // Usually you will only assign something here if the file could not be uploaded.
 $message = 'The uploaded file has been renamed';
 
-echo "<script type='text/javascript'>window.parent.CKEDITOR.tools.callFunction($funcNum, '$url', '$message');";
+echo "<script type='text/javascript'>window.parent.CKEDITOR.tools.callFunction($funcNum, '$url', '$message');</script>";
 ?>
 </body>
 </html>

--- a/docs/guide/dev/integration/file_browse_upload/file_upload/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/file_upload/README.md
@@ -63,24 +63,28 @@ When the file is uploaded successfully, a JSON response with the following entri
 
 **Example**
 
-	{
-		"uploaded": 1,
-		"fileName": "foo.jpg",
-		"url": "/files/foo.jpg"
-	}
+```js
+{
+	"uploaded": 1,
+	"fileName": "foo.jpg",
+	"url": "/files/foo.jpg"
+}
+```
 
 It is also possible to set an error message to indicate that the file upload was completed but some non-standard situation occurred.
 
 **Example**
 
-	{
-		"uploaded": 1,
-		"fileName": "foo(2).jpg",
-		"url": "/files/foo(2).jpg",
-		"error": {
-			"message": "A file with the same name already exists. The uploaded file was renamed to \"foo(2).jpg\"."
-		}
+```js
+{
+	"uploaded": 1,
+	"fileName": "foo(2).jpg",
+	"url": "/files/foo(2).jpg",
+	"error": {
+		"message": "A file with the same name already exists. The uploaded file was renamed to \"foo(2).jpg\"."
 	}
+}
+```
 
 #### Response: File Could Not Be Uploaded
 
@@ -89,7 +93,7 @@ When a file could not be uploaded, a JSON response with the following entries is
  * `uploaded` &ndash; Set to `0`.
  * `error.message` &ndash; The error message to display to the user.
 
-```
+```js
 {
 	"uploaded": 0,
 	"error": {

--- a/docs/guide/dev/integration/jquery/README.md
+++ b/docs/guide/dev/integration/jquery/README.md
@@ -24,9 +24,9 @@ Thanks to the jQuery Adapter every `textarea` element can be converted into a {@
 
 In order to create editor instances, load the jQuery script file, the CKEditor core script file as well as the jQuery Adapter file, in the following order:
 
-	<script src="jquery.js"/>
-	<script src="ckeditor.js"/>
-	<script src="adapters/jquery.js"/>
+	<script src="jquery.js"></script>
+	<script src="ckeditor.js"></script>
+	<script src="adapters/jquery.js"></script>
 
 At this point you can transform elements into a rich text editor by using the {@linkapi CKEDITOR_Adapters.jQuery#ckeditor ckeditor()} method.
 
@@ -127,7 +127,7 @@ For example you can write the following HTML code:
 	<form>
 		<textarea>Lorem ipsum</textarea>
 		<input type="submit" value="Save">
-	</input></form>
+	</form>
 
 And some JavaScript code:
 

--- a/docs/guide/dev/package_managers/README.md
+++ b/docs/guide/dev/package_managers/README.md
@@ -54,7 +54,7 @@ You may add CKEditor to the dependencies list by using the `--save` flag:
 
 or by manually editing your `package.json` file. Just make sure to create a reference to `ckeditor` in the `dependencies` property.
 
-```
+```js
 {
     "name": "my-project",
     "dependencies": {
@@ -87,7 +87,7 @@ By default CKEditor will be placed in the `bower_components/ckeditor` directory.
 
 You may add CKEditor to the dependencies list inside your `bower.json` file. Just make sure to create a reference to `ckeditor` in the `dependencies` property.
 
-```
+```js
 {
     "name": "my-project",
     "dependencies": {
@@ -116,7 +116,7 @@ This article assumes that you have **Composer** already up and running. If this 
 
 In order to fetch the most recent CKEditor 4 build, create a `composer.json` file in the directory where you want to install CKEditor. This file should include the  following contents:
 
-```
+```js
 {
     "require": {
         "ckeditor/ckeditor": "4.*"
@@ -146,7 +146,7 @@ stable | `dev-stable` | `dev-basic/stable` | `dev-standard/stable` | `dev-full/s
 
 For example, let us consider that we want to include the `full` preset of the most up-to-date `4.3.x` release. In this case the `composer.json` file should contain the following code:
 
-```
+```js
 {
     "require": {
         "ckeditor/ckeditor": "dev-full/4.3.x"

--- a/docs/guide/dev/plugins/README.md
+++ b/docs/guide/dev/plugins/README.md
@@ -56,7 +56,7 @@ Using online builder is a recommended solution, however, if you have plugins dev
 
 2. **Copy** the plugin files to the `plugins` folder of your CKEditor installation. Each plugin must be placed in a sub-folder that matches its "technical" name.
 
-	For example, the [Language plugin](https://ckeditor.com/cke4/addon/language) would be installed into this folder: `<CKEditor folder="">/plugins/language`.
+	For example, the [Language plugin](https://ckeditor.com/cke4/addon/language) would be installed into this folder: `<CKEditor folder>/plugins/language`.
 
 3. **Check and resolve plugin dependencies.** If a plugin needs others to work, you will need to add these manually as well.
 

--- a/docs/guide/dev/section508/README.md
+++ b/docs/guide/dev/section508/README.md
@@ -25,32 +25,32 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(a) When software is designed to run on a system that has a keyboard, product functions shall be executable from a keyboard where the function itself or the result of performing a function can be discerned textually.</td>
 <td align="left">All CKEditor features can be reached with keyboard. {@link guide/dev/features/shortcuts/README Keyboard shortcuts} are available for the most frequently used features.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(b) Applications shall not disrupt or disable activated features of other products that are identified as accessibility features, where those features are developed and documented according to industry standards. Applications also shall not disrupt or disable activated features of any operating system that are identified as accessibility features where the application programming interface for those accessibility features has been documented by the manufacturer of the operating system and is available to the product developer.</td>
 <td align="left">CKEditor is an application intended to be run inside a web browser, therefore it does not communicate directly with Assistive Technology. It is, however, developed in a way that ensures its full cooperation with browser accessibility features.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(c) A well-defined on-screen indication of the current focus shall be provided that moves among interactive interface elements as the input focus changes. The focus shall be programmatically exposed so that Assistive Technology can track focus and focus changes.</td>
 <td align="left">CKEditor ensures that every focused element of its UI has a visual sign of that fact, e.g. an outline for buttons. Moreover, the editor exposes the currently focused element to Assistive Technology.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(d) Sufficient information about a user interface element including the identity, operation and state of the element shall be available to Assistive Technology. When an image represents a program element, the information conveyed by the image must also be available in text.</td>
 <td align="left"><ul> <li>Every UI element that has a changeable state exposes its current state to Assistive Technology via WAI-ARIA bindings.</li> <li>Every UI element that contains an image provides its content as a text via an <code>alt</code> attribute or in another textual representation.</li></ul></td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(e) When bitmap images are used to identify controls, status indicators, or other programmatic elements, the meaning assigned to those images shall be consistent throughout an application's performance.</td>
 <td align="left">CKEditor uses distinctive icons for all of its features. Icon meanings are also consistent with commonly used icon meanings throughout the software industry.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(f) Textual information shall be provided through operating system functions for displaying text. The minimum information that shall be made available is text content, text input caret location, and text attributes.</td>
 <td align="left">CKEditor is built on top of operating system functions for displaying text that are provided by a web browser. All neccessary information is provided to end-user.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(g) Applications shall not override user selected contrast and color selections and other individual display attributes.</td>
@@ -69,7 +69,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(i) Color coding shall not be used as the only means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.</td>
 <td align="left">All information conveyed with color, including the color selector, is also available without color through textual labels or exposing its current value to Assistive Technology.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(j) When a product permits a user to adjust color and contrast settings, a variety of color selections capable of producing a range of contrast levels shall be provided.</td>
@@ -88,7 +88,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(l) When electronic forms are used, the form shall allow people using Assistive Technology to access the information, field elements, and functionality required for completion and submission of the form, including all directions and cues.</td>
 <td align="left"><ul><li>When CKEditor is embedded inside a form, <kbd>Tab</kbd> order works with the editor like any other regular form input.</li> <li>The editor is designed to let screen readers read out its name.</li> <li>All form elements inside the editor dialogs have proper labels exposed to Assistive Technology. Additionally, all form elements can be reached with keyboard.</li></ul></td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 </tbody></table>
 
@@ -104,7 +104,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(a) A text equivalent for every non-text element shall be provided (e.g., via <code>alt</code>, <code>longdesc</code>, or in element content).</td>
 <td align="left">All images conveying information, such as toolbar icons, are readable in screen readers via a text label or <code>alt</code>.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(b) Equivalent alternatives for any multimedia presentation shall be synchronized with the presentation.</td>
@@ -118,7 +118,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <li>Toolbar buttons will appear as textual buttons in operating system High Contrast mode.</li>
 <li>Selection of text and background colors is still possible with textual labels in the color selection panels.</li>
 </ul></td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(d) Documents shall be organized so they are readable without requiring an associated style sheet.</td>
@@ -152,7 +152,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(i) Frames shall be titled with text that facilitates frame identification and navigation.</td>
 <td align="left">Iframe elements in CKEditor (such as the WYSIWYG editing area and drop-down lists) are given screen reader accessible labels.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(j) Pages shall be designed to avoid causing the screen to flicker with a frequency greater than 2 Hz and lower than 55 Hz.</td>
@@ -162,12 +162,12 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(k) A text-only page, with equivalent information or functionality, shall be provided to make a web site comply with the provisions of this part, when compliance cannot be accomplished in any other way. The content of the text-only page shall be updated whenever the primary page changes.</td>
 <td align="left">CKEditor is designed to progressively enhance an existing <code>textarea</code> or another element with content, so the text-only alternative is available if JavaScript execution is disabled or an error is encountered.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(l) When pages utilize scripting languages to display content, or to create interface elements, the information provided by the script shall be identified with functional text that can be read by Assistive Technology.</td>
 <td align="left">All UI elements (e.g. toolbar buttons, dialog tabs) in CKEditor come with screen reader accessible labels.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(m) When a web page requires that an applet, plug-in or other application be present on the client system to interpret page content, the page must provide a link to a plug-in or applet that complies with §1194.21(a) through (l).</td>
@@ -181,7 +181,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <li>When CKEditor is embedded inside a form, <kbd>Tab</kbd> order works with the editor like with any other regular form input.</li> <li>CKEditor is designed to let screen readers read out its name.</li>
 <li>All form elements inside the editor dialogs have proper labels exposed to Assistive Technology. Additionally, all form elements can be reached with keyboard.</li>
 </ul></td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(o) A method shall be provided that permits users to skip repetitive navigation links.</td>
@@ -191,7 +191,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <li>The toolbar can be accessed with <kbd>Alt+F10</kbd> and it is divided into groups that can be navigated with the <kbd>Tab</kbd> key. The navigation inside those groups is possible with <kbd>Arrow</kbd> keys.</li>
 <li>{@link guide/dev/features/shortcuts/README Keyboard shortcuts} are available for the most frequently used features.</li>
 </ul></td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(p) When a timed response is required, the user shall be alerted and given sufficient time to indicate more time is required.</td>
@@ -308,12 +308,12 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(d) All training and informational video and multimedia productions which support the agency's mission, regardless of format, that contain visual information necessary for the comprehension of the content, shall be audio described.</td>
 <td align="left"><a href="https://www.youtube.com/user/CKEditor/videos">Screencasts showcasing CKEditor</a> are additional promotional materials connected with articles containing very detailed instructions about doing specified tasks. They are thus not standalone productions, but a supplement to textual content which can be read aloud by Assistive Technology.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(e) Display or presentation of alternate text presentation or audio descriptions shall be user-selectable unless permanent.</td>
 <td align="left">Information contained in <a href="https://www.youtube.com/user/CKEditor/videos">screencasts showcasing CKEditor</a> is also available in the text form on the blog as they are just supplements to textual content. Therefore text presentation is completely user-selectable as it is the primary source of content.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 </tbody></table>
 
@@ -461,7 +461,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <li>{@link guide/dev/features/shortcuts/README Keyboard shortcuts} are available for the most frequently used features.</li>
 <li>The use of user speech is not required for operating the editor.</li>
 </ul></td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(f) At least one mode of operation and information retrieval that does not require fine motor control or simultaneous actions and that is operable with limited reach and strength shall be provided.</td>
@@ -471,7 +471,7 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <li>{@link guide/dev/features/shortcuts/README Keyboard shortcuts} are available for the most frequently used features.</li>
 <li>A mouse is thus not required for using the editor.</li>
 </ul></td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 </tbody></table>
 
@@ -487,17 +487,17 @@ The Voluntary Product Accessibility Template (VPAT) for Section 508 can be retri
 <tr>
 <td align="left">(a) Product support documentation provided to end-users shall be made available in alternate formats upon request, at no additional charge.</td>
 <td align="left">Documentation is available in alternate formats and is delivered to end-users upon request, at no additional charge.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(b) End-users shall have access to a description of the accessibility and compatibility features of products in alternate formats or alternate methods upon request, at no additional charge.</td>
 <td align="left">Description of the accessibility and compatibility features of CKEditor is available in alternate formats and methods upon request, at no additional charge.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 <tr>
 <td align="left">(c) Support services for products shall accommodate the communication needs of end-users with disabilities.</td>
 <td align="left">The main way of providing support to end-users is via e-mail; it enables users to use their Assistive Technology with it. Additionaly, there is also an option to get support via a phone call.</td>
-<td align="left"/>
+<td align="left"></td>
 </tr>
 </tbody></table>
 

--- a/docs/guide/dev/skins/README.md
+++ b/docs/guide/dev/skins/README.md
@@ -56,7 +56,7 @@ Using online builder is a recommended solution, however, if you have skins devel
 
 2. **Copy** the skin files to the `skins` folder of your CKEditor installation. Each skin must be placed in a sub-folder that matches its "technical" name.
 
-	For example, the [Kama skin](https://ckeditor.com/cke4/addon/kama) would be installed into this folder: `<CKEditor folder="">/skins/kama`.
+	For example, the [Kama skin](https://ckeditor.com/cke4/addon/kama) would be installed into this folder: `<CKEditor folder>/skins/kama`.
 
 3. **Enable the skin.** Use the {@linkapi CKEDITOR.config#skin skin} setting to add the skin to your confiuration:
 

--- a/docs/guide/dev/tests/README.md
+++ b/docs/guide/dev/tests/README.md
@@ -24,13 +24,17 @@ To run CKEditor tests you will need [Bender.js](https://github.com/benderjs/bend
 
 First, you need to install globally the [Bender.js command line interface](https://github.com/benderjs/benderjs-cli). To do so, open the console and use `npm install`:
 
-	> npm install -g benderjs-cli
+```sh
+> npm install -g benderjs-cli
+```
 
 **Note:** You may need administrative rights to do this (e.g. `sudo`).
 
 Now you can check whether Bender.js has installed properly. If you run Bender.js in the console:
 
-	> bender
+```sh
+> bender
+```
 
 you should see the following message:
 
@@ -48,15 +52,21 @@ First of all, you need to {@link guide/dev/source/README clone the CKEditor deve
 
 Go to the main CKEditor directory (it should contain the `bender.js`, `package.json` files, among others, and the `tests/` directory):
 
-	> cd ckeditor-dev
+```sh
+> cd ckeditor-dev
+```
 
 You will now need to install the Bender.js engine (`benderjs-cli` installed globally uses a local `benderjs` module) and all required modules, like the [Sinon.JS plugin for Bender.js](https://github.com/benderjs/benderjs-sinon). To do so use:
 
-	> npm install
+```sh
+> npm install
+```
 
 Then you need to initialize the Bender project:
 
-	> bender init
+```sh
+> bender init
+```
 
 This command will create the `.bender/` directory which contains Bender.js's cache, databases, and a local configuration file.
 
@@ -66,7 +76,9 @@ You do not need to perform any additional configuration steps as `bender.js` is 
 
 In order to run the tests, open the console and type:
 
-	> bender server run
+```sh
+> bender server run
+```
 
 This will start the server in the verbose mode.
 
@@ -75,11 +87,15 @@ This will start the server in the verbose mode.
 
 Now open a web browser. Bender.js dashboard is available under:
 
-	http://localhost:1030
+```sh
+http://localhost:1030
+```
 
 **Note:** You can also run the server as a daemon:
 
-	> bender server start
+```sh
+> bender server start
+```
 
 At the moment, starting a daemon is supported **on Unix systems only**.
 
@@ -97,26 +113,28 @@ Please note that at the moment some random tests may fail in Internet Explorer. 
 
 In the Bender.js dashboard you can run all (or part) of the tests located in the CKEditor `tests/` directory. These tests are organized into subdirectories based on what they are testing:
 
-	tests/
-		adapters/
-			(design tests for editor adapters, located in the adapters/ folder)
-			jquery/
-		core/
-			(design tests for editor core features, located in the core/ folder)
-			dom/
-			htmlparser/
-			...
-		plugins/
-			(design tests for editor plugins, located in the plugins/ folder)
-			about/
-			button/
-			...
-		tickets/
-			(functional tests for specific tickets (http://dev.ckeditor.com/report) which are not
-				related to any specific features or are related to multiple features and plugins)
-			10146/
-			10212/
-			...
+```html
+tests/
+	adapters/
+		(design tests for editor adapters, located in the adapters/ folder)
+		jquery/
+	core/
+		(design tests for editor core features, located in the core/ folder)
+		dom/
+		htmlparser/
+		...
+	plugins/
+		(design tests for editor plugins, located in the plugins/ folder)
+		about/
+		button/
+		...
+	tickets/
+		(functional tests for specific tickets (http://dev.ckeditor.com/report) which are not
+			related to any specific features or are related to multiple features and plugins)
+		10146/
+		10212/
+		...
+```
 
 <info-box hint=""> As long as a test is related to a particular feature or a plugin, it should be put into the <code>adapters/</code>, <code>core/</code>, or <code>plugins/</code> directory. Ticket tests are most difficult to manage so the <code>tickets/</code> directory should only contain the tests that do not match any of these primary locations.
 </info-box>
@@ -166,7 +184,7 @@ In case of unit tests the `bender-tags` meta comment should be placed in the `*.
 #### For Manual Tests Only
 
 * `bug/feature` &ndash; A test covers a bug fix or a new feature.
-* `<CKEditor version="">`, e.g. `4.6.2`, `4.7.0` &ndash; A targeted version of CKEditor by this given patch (usually means an upcoming minor or major release).
+* `<CKEditor version>`, e.g. `4.6.2`, `4.7.0` &ndash; A targeted version of CKEditor by this given patch (usually means an upcoming minor or major release).
 
 There might be a situation where a single `*.js` file contains many tests and referencing a specific issue in `bender-tags` might be misleading. In such cases, the issue should be referenced right before the specific test which covers the issue:
 
@@ -182,7 +200,7 @@ If there is a need to reference a Trac issue instead of the GitHub one, full URL
 
     // (http://dev.ckeditor.com/ticket/<number>)
     'test some Trac issue scenario 1...'
-        
+
     // Additional comment (http://dev.ckeditor.com/ticket/<number>).
     'test some Trac issue scenario 2...'
 
@@ -236,7 +254,7 @@ If you need, you can add the entire content of the `<html>` page element, for ex
 
 ``` html
 <head>
-    <script src="_helpers/tools.js"/>
+    <script src="_helpers/tools.js"></script>
 </head>
 <body>
     <textarea id="editor">Lorem ipsum</textarea>

--- a/docs/guide/plugin_sdk/integration_with_acf/README.md
+++ b/docs/guide/plugin_sdk/integration_with_acf/README.md
@@ -177,17 +177,19 @@ enabled and which are not, depending on filtering rules set in the configuration
 be done by modifying the Explanation field in the dialog window definition
 (`plugins/abbr/dialogs/abbr.js`):
 
-	elements: [
+```js
+elements: [
+	...
+	{
+		type: 'text',
+		id: 'title',
+		label: 'Explanation',
+		requiredContent: 'abbr[title]',	// Title must be allowed to enable this field.
 		...
-		{
-			type: 'text',
-			id: 'title',
-			label: 'Explanation',
-			requiredContent: 'abbr[title]',	// Title must be allowed to enable this field.
-			...
-		}
-		...
-	]
+	}
+	...
+]
+```
 
 The dialog window also contains the **Advanced Settings** tab that
 can be used for setting the `id` attribute. However, our current configuration
@@ -195,18 +197,20 @@ can be used for setting the `id` attribute. However, our current configuration
 attributes". The **Abbreviation** plugin should take this fact into account and disable
 the **Advanced Settings** tab unless the `id` attribute is allowed:
 
-	contents: [
-		...
-		{
-			id: 'tab-adv',
-			label: 'Advanced Settings',
-			requiredContent: 'abbr[id]',	// ID must be allowed to enable this field.
-			elements: [
-				...
-			]
-		}
-		...
-	]
+```js
+contents: [
+	...
+	{
+		id: 'tab-adv',
+		label: 'Advanced Settings',
+		requiredContent: 'abbr[id]',	// ID must be allowed to enable this field.
+		elements: [
+			...
+		]
+	}
+	...
+]
+```
 
 To sum it up, let us see how the **Abbreviation** dialog window changes with different
 `config.allowedContent` settings:

--- a/docs/guide/plugin_sdk/sample_1/README.md
+++ b/docs/guide/plugin_sdk/sample_1/README.md
@@ -115,7 +115,7 @@ CKEDITOR.config.extraPlugins configuration option:
 
 <info-box info=""> Please note that <strong>since CKEditor 4.1 all editor plugins that create content should be integrated with {@link guide/dev/acf/README Advanced Content Filter} (ACF)</strong>. <br>
  To follow this guide and at the same time comply with the new CKEditor 4.1 requirements you need to either set <code>config.allowedContent = true;</code> in order to disable {@link guide/dev/deep_dive/advanced_content_filter/README content filtering} or {@link guide/plugin_sdk/integration_with_acf/README integrate your plugin with ACF}. For more information, please refer to the official {@link guide/plugin_sdk/integration_with_acf/README Advanced Content Filter integration guide}.
-</br></info-box>
+</info-box>
 
 Now load a CKEditor sample page. You should be able to see the new plugin toolbar button in the toolbar. For example:
 
@@ -208,37 +208,39 @@ the user to assign an ID to the abbreviation element.
 The code snippet presented below shows a full definition of the contents of both
 plugin tabs.
 
-	contents: [
-		{
-			id: 'tab-basic',
-			label: 'Basic Settings',
-			elements: [
-				{
-					type: 'text',
-					id: 'abbr',
-					label: 'Abbreviation',
-					validate: CKEDITOR.dialog.validate.notEmpty( "Abbreviation field cannot be empty." )
-				},
-				{
-					type: 'text',
-					id: 'title',
-					label: 'Explanation',
-					validate: CKEDITOR.dialog.validate.notEmpty( "Explanation field cannot be empty." )
-				}
-			]
-		},
-		{
-			id: 'tab-adv',
-			label: 'Advanced Settings',
-			elements: [
-				{
-					type: 'text',
-					id: 'id',
-					label: 'Id'
-				}
-			]
-		}
-	]
+```js
+contents: [
+	{
+		id: 'tab-basic',
+		label: 'Basic Settings',
+		elements: [
+			{
+				type: 'text',
+				id: 'abbr',
+				label: 'Abbreviation',
+				validate: CKEDITOR.dialog.validate.notEmpty( "Abbreviation field cannot be empty." )
+			},
+			{
+				type: 'text',
+				id: 'title',
+				label: 'Explanation',
+				validate: CKEDITOR.dialog.validate.notEmpty( "Explanation field cannot be empty." )
+			}
+		]
+	},
+	{
+		id: 'tab-adv',
+		label: 'Advanced Settings',
+		elements: [
+			{
+				type: 'text',
+				id: 'id',
+				label: 'Id'
+			}
+		]
+	}
+]
+```
 
 When you reload the editor instance and open the **Abbreviation Properties** dialog
 window, the **Basic Settings** tab will now contain two mandatory text fields.
@@ -278,19 +280,21 @@ document at the location of the cursor by using the
 Add the following `onOk` function code to your dialog window definition, below
 the code that creates the content of the dialog.
 
-	onOk: function() {
-		var dialog = this;
-		var abbr = editor.document.createElement( 'abbr' );
+```js
+onOk: function() {
+	var dialog = this;
+	var abbr = editor.document.createElement( 'abbr' );
 
-		abbr.setAttribute( 'title', dialog.getValueOf( 'tab-basic', 'title' ) );
-		abbr.setText( dialog.getValueOf( 'tab-basic', 'abbr' ) );
+	abbr.setAttribute( 'title', dialog.getValueOf( 'tab-basic', 'title' ) );
+	abbr.setText( dialog.getValueOf( 'tab-basic', 'abbr' ) );
 
-		var id = dialog.getValueOf( 'tab-adv', 'id' );
-		if ( id )
-			abbr.setAttribute( 'id', id );
+	var id = dialog.getValueOf( 'tab-adv', 'id' );
+	if ( id )
+		abbr.setAttribute( 'id', id );
 
-		editor.insertElement( abbr );
-	}
+	editor.insertElement( abbr );
+}
+```
 
 <info-box hint=""> Please note that another way to insert HTML code into CKEditor is by using the {@linkapi CKEDITOR.editor#insertHtml insertHtml} function that adds HTML code at the location of the cursor in the document: <code>editor.insertHtml( '&lt;h2>This is a sample header&lt;/h2>&lt;p>This is a sample paragraph.&lt;/p>' );</code>
 </info-box>

--- a/docs/guide/plugin_sdk/sample_2/README.md
+++ b/docs/guide/plugin_sdk/sample_2/README.md
@@ -28,7 +28,7 @@ If you have any doubts about the content of the plugin and its configuration, re
 
 <info-box info=""> Please note that <strong>since CKEditor 4.1 all editor plugins that create content should be integrated with {@link guide/dev/acf/README Advanced Content Filter} (ACF)</strong>. <br>
  To follow this guide and at the same time comply with the new CKEditor 4.1 requirements you need to either set <code>config.allowedContent = true;</code> in order to disable {@link guide/dev/deep_dive/advanced_content_filter/README content filtering} or {@link guide/plugin_sdk/integration_with_acf/README integrate your plugin with ACF}. For more information, please refer to the official {@link guide/plugin_sdk/integration_with_acf/README Advanced Content Filter integration guide}.
-</br></info-box>
+</info-box>
 
 ## Context Menu Support
 
@@ -168,41 +168,45 @@ case we will need to get the content of the `title` attribute of the `<abbr>`
 element by using the {@linkapi CKEDITOR.dom.element#getAttribute getAttribute}
 method in order to populate the field with its value by using the `setValue` method again.
 
-	elements: [
-		{
-			type: 'text',
-			id: 'abbr',
-			label: 'Abbreviation',
-			validate: CKEDITOR.dialog.validate.notEmpty( "Abbreviation cannot be empty." ),
-			setup: function( element ) {
-				this.setValue( element.getText() );
-			}
-		},
-		{
-			type: 'text',
-			id: 'title',
-			label: 'Explanation',
-			validate: CKEDITOR.dialog.validate.notEmpty( "Title cannot be empty." ),
-			setup: function( element ) {
-				this.setValue( element.getAttribute( "title" ) );
-			}
+```js
+elements: [
+	{
+		type: 'text',
+		id: 'abbr',
+		label: 'Abbreviation',
+		validate: CKEDITOR.dialog.validate.notEmpty( "Abbreviation cannot be empty." ),
+		setup: function( element ) {
+			this.setValue( element.getText() );
 		}
-	]
+	},
+	{
+		type: 'text',
+		id: 'title',
+		label: 'Explanation',
+		validate: CKEDITOR.dialog.validate.notEmpty( "Title cannot be empty." ),
+		setup: function( element ) {
+			this.setValue( element.getAttribute( "title" ) );
+		}
+	}
+]
+```
 
 Since the **Advanced Settings** tab contains a single **Id** text field that reflects
 the content of the `id` attribute, we will use the same combination of the
 `getAttribute` and `setValue` methods as in case of the **Explanation** text field.
 
-	elements: [
-		{
-			type: 'text',
-			id: 'id',
-			label: 'Id',
-			setup: function( element ) {
-				this.setValue( element.getAttribute( "id" ) );
-			}
+```js
+elements: [
+	{
+		type: 'text',
+		id: 'id',
+		label: 'Id',
+		setup: function( element ) {
+			this.setValue( element.getAttribute( "id" ) );
 		}
-	]
+	}
+]
+```
 
 When you reload the page, add an abbreviation, and then attempt to modify it by
 opening the context menu and selecting **Edit Abbreviation**, the **Abbreviation
@@ -243,15 +247,17 @@ We then use the {@linkapi CKEDITOR.dialog#commitContent commitContent} method to
 populate the element with values entered by the user. Every parameter that is
 passed to the `commitContent` method will also be passed on to the commit functions.
 
-	onOk: function() {
-		var dialog = this,
-			abbr = dialog.element;
+```js
+onOk: function() {
+	var dialog = this,
+		abbr = dialog.element;
 
-		dialog.commitContent( abbr );
+	dialog.commitContent( abbr );
 
-		if ( dialog.insertMode )
-			editor.insertElement( abbr );
-	}
+	if ( dialog.insertMode )
+		editor.insertElement( abbr );
+}
+```
 
 To make the `commitContent` method work we will however first need to define
 the {@linkapi CKEDITOR.dialog.definition.uiElement#commit commit} functions themselves.
@@ -267,32 +273,34 @@ content, although in this case we will need to set the content of the
 `title` attribute of the `<abbr>` element by using the
 {@linkapi CKEDITOR.dom.element#setAttribute setAttribute} method.
 
-	elements: [
-		{
-			type: 'text',
-			id: 'abbr',
-			label: 'Abbreviation',
-			validate: CKEDITOR.dialog.validate.notEmpty( "Abbreviation cannot be empty." ),
-			setup: function( element ) {
-				this.setValue( element.getText() );
-			},
-			commit: function( element ) {
-				element.setText( this.getValue() );
-			}
+```js
+elements: [
+	{
+		type: 'text',
+		id: 'abbr',
+		label: 'Abbreviation',
+		validate: CKEDITOR.dialog.validate.notEmpty( "Abbreviation cannot be empty." ),
+		setup: function( element ) {
+			this.setValue( element.getText() );
 		},
-		{
-			type: 'text',
-			id: 'title',
-			label: 'Explanation',
-			validate: CKEDITOR.dialog.validate.notEmpty( "Title cannot be empty." ),
-			setup: function( element ) {
-				this.setValue( element.getAttribute( "title" ) );
-			},
-			commit: function( element ) {
-				element.setAttribute( "title", this.getValue() );
-			}
+		commit: function( element ) {
+			element.setText( this.getValue() );
 		}
-	]
+	},
+	{
+		type: 'text',
+		id: 'title',
+		label: 'Explanation',
+		validate: CKEDITOR.dialog.validate.notEmpty( "Title cannot be empty." ),
+		setup: function( element ) {
+			this.setValue( element.getAttribute( "title" ) );
+		},
+		commit: function( element ) {
+			element.setAttribute( "title", this.getValue() );
+		}
+	}
+]
+```
 
 Similarly, since the **Advanced Settings** tab contains an `Id` text field that
 reflects the content of the `id` attribute, we will use the same combination
@@ -304,23 +312,25 @@ means we are editing an existing element) and the `Id` field is empty, we
 will use the {@linkapi CKEDITOR.dom.element#removeAttribute removeAttribute} method to
 delete the `id` element of an existing abbreviation.
 
-	elements: [
-		{
-			type: 'text',
-			id: 'id',
-			label: 'Id',
-			setup: function( element ) {
-				this.setValue( element.getAttribute( "id" ) );
-			},
-			commit: function ( element ) {
-				var id = this.getValue();
-				if ( id )
-					element.setAttribute( 'id', id );
-				else if ( !this.insertMode )
-					element.removeAttribute( 'id' );
-			}
+```js
+elements: [
+	{
+		type: 'text',
+		id: 'id',
+		label: 'Id',
+		setup: function( element ) {
+			this.setValue( element.getAttribute( "id" ) );
+		},
+		commit: function ( element ) {
+			var id = this.getValue();
+			if ( id )
+				element.setAttribute( 'id', id );
+			else if ( !this.insertMode )
+				element.removeAttribute( 'id' );
 		}
-	]
+	}
+]
+```
 
 ## Full Source Code
 

--- a/docs/guide/skin_sdk/build/README.md
+++ b/docs/guide/skin_sdk/build/README.md
@@ -20,7 +20,9 @@ To do so you'll need CKBuilder a Java application that makes this magic happen. 
 
 [Java](http://java.com/en/download/) must be available on your command line. To run the builder, simply copy `ckbuilder.jar` into the `skins` folder of CKEditor (where your skin custom folder is available) and execute this command:
 
-	 > java -jar ckbuilder.jar --build-skin myskin myskin-release
+```sh
+> java -jar ckbuilder.jar --build-skin myskin myskin-release
+```
 
 The `myskin` and `myskin-release` parts are your skin folder name and the destination folder name. Just use the names you prefer.
 

--- a/docs/guide/skin_sdk/compatibility_with_ckeditor_4_5/README.md
+++ b/docs/guide/skin_sdk/compatibility_with_ckeditor_4_5/README.md
@@ -116,7 +116,9 @@ You can add support for displaying that a dialog window is in a busy state by fo
 
 To test it, open the `samples/index.html` file in your browser, then open some dialog window (e.g. the Link dialog) and execute the following code in the console:
 
-	CKEDITOR.dialog.getCurrent().setState( {@linkapi CKEDITOR.DIALOG_STATE_BUSY CKEDITOR.DIALOG_STATE_BUSY} );
+```js
+CKEDITOR.dialog.getCurrent().setState( {@linkapi CKEDITOR.DIALOG_STATE_BUSY CKEDITOR.DIALOG_STATE_BUSY} );
+```
 
 You should see a spinner in the dialog's title bar.
 

--- a/docs/guide/widget_sdk/tutorial_1/README.md
+++ b/docs/guide/widget_sdk/tutorial_1/README.md
@@ -103,7 +103,7 @@ To register the widget plugin with CKEditor, we have to add it to the `{@linkapi
 
 Open the page that will contain CKEditor in a text editor and insert a CKEditor instance using the following configuration.
 
-	<textarea cols="80" id="editor1" name="editor1" rows="10"/>
+	<textarea cols="80" id="editor1" name="editor1" rows="10"></textarea>
 	<script>
 		CKEDITOR.replace( 'editor1', {
 			// Load the Simple Box plugin.
@@ -182,27 +182,29 @@ Each CKEditor plugin, included widgets, can add its own styles for editor conten
 
 To simplify the tutorial, let us assume you are using the {@link guide/dev/framed/README classic editor}. The styling of classic editor content is done by using the `contents.css` file. Add the styles below to your default `contents.css` file:
 
-	.simplebox {
-		padding: 8px;
-		margin: 10px;
-		background: #eee;
-		border-radius: 8px;
-		border: 1px solid #ddd;
-		box-shadow: 0 1px 1px #fff inset, 0 -1px 0px #ccc inset;
-	}
-	.simplebox-title, .simplebox-content {
-		box-shadow: 0 1px 1px #ddd inset;
-		border: 1px solid #cccccc;
-		border-radius: 5px;
-		background: #fff;
-	}
-	.simplebox-title {
-		margin: 0 0 8px;
-		padding: 5px 8px;
-	}
-	.simplebox-content {
-		padding: 0 8px;
-	}
+```css
+.simplebox {
+	padding: 8px;
+	margin: 10px;
+	background: #eee;
+	border-radius: 8px;
+	border: 1px solid #ddd;
+	box-shadow: 0 1px 1px #fff inset, 0 -1px 0px #ccc inset;
+}
+.simplebox-title, .simplebox-content {
+	box-shadow: 0 1px 1px #ddd inset;
+	border: 1px solid #cccccc;
+	border-radius: 5px;
+	background: #fff;
+}
+.simplebox-title {
+	margin: 0 0 8px;
+	padding: 5px 8px;
+}
+.simplebox-content {
+	padding: 0 8px;
+}
+```
 
 Please note that if you are working with the {@link guide/dev/inline/README inline editor}, you need to add these styles to your page that displays the editor. And if you want to share your plugin with others, refer to the {@link guide/plugin_sdk/styles/README Plugin CSS Styles} article that explains the recommended way to control plugin styling.
 
@@ -315,68 +317,72 @@ Anyway, this is it. The widget code is complete now and works as intended!
 
 The full contents of the `simplebox/plugin.js` file is as follows:
 
-	CKEDITOR.plugins.add( 'simplebox', {
-		requires: 'widget',
+```js
+CKEDITOR.plugins.add( 'simplebox', {
+	requires: 'widget',
 
-		icons: 'simplebox',
+	icons: 'simplebox',
 
-		init: function( editor ) {
-			editor.widgets.add( 'simplebox', {
+	init: function( editor ) {
+		editor.widgets.add( 'simplebox', {
 
-				button: 'Create a simple box',
+			button: 'Create a simple box',
 
-				template:
-					'<div class="simplebox">' +
-						'<h2 class="simplebox-title">Title</h2>' +
-						'<div class="simplebox-content"><p>Content...</p></div>' +
-					'</div>',
+			template:
+				'<div class="simplebox">' +
+					'<h2 class="simplebox-title">Title</h2>' +
+					'<div class="simplebox-content"><p>Content...</p></div>' +
+				'</div>',
 
-				editables: {
-					title: {
-						selector: '.simplebox-title',
-						allowedContent: 'br strong em'
-					},
-					content: {
-						selector: '.simplebox-content',
-						allowedContent: 'p br ul ol li strong em'
-					}
+			editables: {
+				title: {
+					selector: '.simplebox-title',
+					allowedContent: 'br strong em'
 				},
-
-				allowedContent:
-					'div(!simplebox); div(!simplebox-content); h2(!simplebox-title)',
-
-				requiredContent: 'div(simplebox)',
-
-				upcast: function( element ) {
-					return element.name == 'div' && element.hasClass( 'simplebox' );
+				content: {
+					selector: '.simplebox-content',
+					allowedContent: 'p br ul ol li strong em'
 				}
-			} );
-		}
-	} );
+			},
+
+			allowedContent:
+				'div(!simplebox); div(!simplebox-content); h2(!simplebox-title)',
+
+			requiredContent: 'div(simplebox)',
+
+			upcast: function( element ) {
+				return element.name == 'div' && element.hasClass( 'simplebox' );
+			}
+		} );
+	}
+} );
+```
 
 This should be added to your `contents.css` file:
 
-	.simplebox {
-		padding: 8px;
-		margin: 10px;
-		background: #eee;
-		border-radius: 8px;
-		border: 1px solid #ddd;
-		box-shadow: 0 1px 1px #fff inset, 0 -1px 0px #ccc inset;
-	}
-	.simplebox-title, .simplebox-content {
-		box-shadow: 0 1px 1px #ddd inset;
-		border: 1px solid #cccccc;
-		border-radius: 5px;
-		background: #fff;
-	}
-	.simplebox-title {
-		margin: 0 0 8px;
-		padding: 5px 8px;
-	}
-	.simplebox-content {
-		padding: 0 8px;
-	}
+```css
+.simplebox {
+	padding: 8px;
+	margin: 10px;
+	background: #eee;
+	border-radius: 8px;
+	border: 1px solid #ddd;
+	box-shadow: 0 1px 1px #fff inset, 0 -1px 0px #ccc inset;
+}
+.simplebox-title, .simplebox-content {
+	box-shadow: 0 1px 1px #ddd inset;
+	border: 1px solid #cccccc;
+	border-radius: 5px;
+	background: #fff;
+}
+.simplebox-title {
+	margin: 0 0 8px;
+	padding: 5px 8px;
+}
+.simplebox-content {
+	padding: 0 8px;
+}
+```
 
 <info-box hint=""> You can also <a href="https://github.com/ckeditor/ckeditor-docs-samples/tree/master/tutorial-simplebox-1">download the entire plugin folder</a> including the icon, the fully commented source code, and a working sample. If you have any doubts about the installation process, see the <a href="https://github.com/ckeditor/ckeditor-docs-samples/blob/master/README.md">instructions</a>.
 </info-box>


### PR DESCRIPTION
After porting to Umberto several issues occurred:

* code became valid XML, meaning that it became also invalid HTML (e.g. `<br>` → `<br></br>`, void `script` tags etc.);
* in many places information about language in code listings were lost;
* some code listings were changed into bogus `pre` tags;
* some directory listing, due to `<placeholders>` became… XML code (e.g. `<CKEditor version=""/>`);

Thanks to @Erikmitk for pointing it out.

Closes #168.