### PR TITLE
Fix links in guides and examples

### DIFF
--- a/docs/guide/dev/acf/README.md
+++ b/docs/guide/dev/acf/README.md
@@ -40,7 +40,7 @@ Common use case: Applications whose users are familiar with {@link guide/dev/fea
 
 ### Allow everything, except...
 
-See {@link guide/dev/deep_dive/advanced_content_filter/disallowed_content/README#how-to-allow-everything-except... Disallowed Content} in the Deep Dive section.
+See {@link guide/dev/deep_dive/advanced_content_filter/disallowed_content/README#how-to-allow-everything-except Disallowed Content} in the Deep Dive section.
 
 Common use case: An alternative to allowing just everything, which helps, for example, protect users from accidental copying  of the `<script>` tags or `onclick` handlers from other websites. Keep in mind that blacklisting is usually a bad idea.
 

--- a/docs/guide/dev/contributing_code/README.md
+++ b/docs/guide/dev/contributing_code/README.md
@@ -54,12 +54,14 @@ Note that all patches which change the editor code **must include tests**.
 
 Every change which can be tested automatically should have at least one automated test. Read about {@link guide/dev/tests/README#creating-your-own-test writing tests in Bender.js}.
 
-<info-box hint=""> If you do not know how to write tests for your patch, you can make an {@link guide/dev/contributing/README#proposing-incomplete-patches incomplete pull request} and the core team will give you some hints or perhaps someone else from the community will step in.
+<info-box hint="">
+ If you do not know how to write tests for your patch, you can make an {@link guide/dev/contributing_code/README#proposing-incomplete-patches incomplete pull request} and the core team will give you some hints or perhaps someone else from the community will step in.
 </info-box>
 
 Some types of features or bugs cannot be tested automatically. In such cases, create a manual test (see [this one](https://github.com/ckeditor/ckeditor-dev/tree/master/tests/tickets/12735) for instance).
 
-<info-box hint=""> To see manual tests in the Bender.js dashboard you need to change the filter from <code>is:unit</code> to <code>is:manual</code>.
+<info-box hint="">
+ To see manual tests in the Bender.js dashboard you need to change the filter from <code>is:unit</code> to <code>is:manual</code>.
 </info-box>
 
 ## Creating a Pull Request

--- a/docs/guide/dev/example_setups/README.md
+++ b/docs/guide/dev/example_setups/README.md
@@ -141,7 +141,7 @@ This is the easiest way of using CKEditor if additional third-party plugins are 
 
 Using [Builder](https://ckeditor.com/cke4/builder) to build a bundle with all required plugins is highly recommended in case of using customized packages, especially those with additional third-party plugins.
 
-Refer to the {@link guide/dev/plugins/README#through-ckbuilder Installing Plugins &ndash; Online Builder Installation} article for information about building a custom editor package.
+Refer to the {@link guide/dev/plugins/README#through-online-builder Installing Plugins &ndash; Online Builder Installation} article for information about building a custom editor package.
 
 <table border="1" class="hints">
 <tr><td class="hints-benchmark">Benchmark</td><td class="hints-result">Result</td><td>Comments</td></tr>

--- a/docs/guide/dev/features/drop_paste/README.md
+++ b/docs/guide/dev/features/drop_paste/README.md
@@ -17,7 +17,7 @@ For licensing, see LICENSE.md.
 
 One of the CKEditor features is that it takes care over the input data you paste or drop into the editor. The [Clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin which is included in every preset implements custom input content handling, which means that the editor will handle pasted and &mdash; since version 4.5 &mdash; dropped content.
 
-All pasted and dropped content is passed through the {@linkapi CKEDITOR.editor#paste } event which makes it easy to process it before it is inserted into the editor. This mechanism is used extensively by CKEditor features like {@link guide/dev/features/drop_paste/README#filtering Advanced Content Filter and paste filter}, {@link guide/dev/features/pastefromword/README Paste from Word filter} or {@link guide/dev/features/drop_paste/README#file-upload support for uploading dropped files}.
+All pasted and dropped content is passed through the {@linkapi CKEDITOR.editor#paste } event which makes it easy to process it before it is inserted into the editor. This mechanism is used extensively by CKEditor features like {@link guide/dev/features/drop_paste/README#filtering-content Advanced Content Filter and paste filter}, {@link guide/dev/features/pastefromword/README Paste from Word filter} or {@link guide/dev/features/drop_paste/README#file-upload support for uploading dropped files}.
 
 Note that browsers support clipboard operations differently and because of that the behavior of the drag and drop or copy and paste may be slightly different between browsers.
 

--- a/docs/guide/dev/features/sourcearea/README.md
+++ b/docs/guide/dev/features/sourcearea/README.md
@@ -40,7 +40,7 @@ If you want to use it in an inline editor instance (which by default uses floati
 
 	config.extraPlugins = 'sourcedialog';
 
-<info-box hint="">If you are using the {@link guide/dev/features/toolbar/README#item-by-item-configuration "item by item" toolbar configuration}, note that the button name for the Source dialog is <code>Source<b>d</b>ialog</code>.</info-box>
+<info-box hint="">If you are using the {@link guide/dev/features/toolbarconcepts/README#item-by-item-configuration "item by item" toolbar configuration}, note that the button name for the Source dialog is <code>Source<b>d</b>ialog</code>.</info-box>
 
 If, on the other hand, you want to replace the default source editing area with the source dialog for classic editor with fixed user interface, use the following settings:
 

--- a/docs/guide/dev/features/toolbar/README.md
+++ b/docs/guide/dev/features/toolbar/README.md
@@ -47,7 +47,7 @@ There are two types of toolbar configurator available: the **basic**, more visua
 
 ### Basic Toolbar Configurator
 
-The basic toolbar configurator uses the "{@link guide/dev/features/toolbar/README#toolbar-groups-configuration toolbar groups}" approach which is the recommended way to arrange the editor toolbar. You can modify the order of the toolbar groups by clicking the Up and Down arrows and toggle button visibility by selecting and deselecting the checkboxes. Use the "Add row separator" button to create a new toolbar row.
+The basic toolbar configurator uses the "{@link guide/dev/features/toolbarconcepts/README#toolbar-groups-configuration toolbar groups}" approach which is the recommended way to arrange the editor toolbar. You can modify the order of the toolbar groups by clicking the Up and Down arrows and toggle button visibility by selecting and deselecting the checkboxes. Use the "Add row separator" button to create a new toolbar row.
 
 {@img assets/img/toolbar_configurator_basic.png CKEditor 4.5 basic toolbar configurator}
 
@@ -55,7 +55,7 @@ When you are happy with your toolbar, click the "Get toolbar config" button to d
 
 ### Advanced Toolbar Configurator
 
-The basic, more visual toolbar configurator is based on the "toolbar groups" concept. However, if you would like to create a completely custom toolbar with an "{@link guide/dev/features/toolbar/README#item-by-item-configuration item by item}" configuration, and precisely define the visibility and position of each toolbar button, you can achieve this with the advanced toolbar configurator.
+The basic, more visual toolbar configurator is based on the "toolbar groups" concept. However, if you would like to create a completely custom toolbar with an "{@link guide/dev/features/toolbarconcepts/README#item-by-item-configuration item by item}" configuration, and precisely define the visibility and position of each toolbar button, you can achieve this with the advanced toolbar configurator.
 
 {@img assets/img/toolbar_configurator_advanced.png CKEditor 4.5 advanced toolbar configurator}
 

--- a/docs/guide/dev/howtos/dialog_windows/README.md
+++ b/docs/guide/dev/howtos/dialog_windows/README.md
@@ -76,7 +76,7 @@ For more examples on setting a default field value refer to the old "Using the J
 
 If you want to change your CKEditor configuration to show a different tab on opening a dialog window, you can hook into the {@linkapi CKEDITOR.dialog.definition#onShow onShow} event of the dialog window.
 
-Firstly, you will need to know the names of the dialog window and the tab that you want to set as default, so use the {@link guide/dev/howtos/dialog_windows/README#how-do-i-learn-the-names-of-ckeditor-dialog-window-fields%3F Developer Tools} plugin to get these.
+Firstly, you will need to know the names of the dialog window and the tab that you want to set as default, so use the {@link guide/dev/howtos/dialog_windows/README#how-do-i-learn-the-names-of-ckeditor-dialog-window-fields Developer Tools} plugin to get these.
 
 Once you have the names you can add the following code into the page that contains your CKEditor instance. The example below sets the [Image Properties](https://ckeditor.com/cke4/addon/image) dialog window to open the **Link** tab by default.
 

--- a/docs/guide/dev/howtos/scayt/README.md
+++ b/docs/guide/dev/howtos/scayt/README.md
@@ -17,14 +17,14 @@ The following article contains tips about customizing the spell checker behavior
 
 ## How Do I Set SCAYT to Turn On Automatically?
 
-If you want to turn on the {@link guide/dev/features/spellcheck/README#spell-check-as-you-type-%28scayt%29 Spell Check As You Type (SCAYT)} feature in CKEditor by default, set the {@linkapi CKEDITOR.config#scayt_autoStartup CKEDITOR.config#scayt_autoStartup} configuration setting to `true`.
+If you want to turn on the {@link guide/dev/features/spellcheck/README#spell-check-as-you-type-scayt Spell Check As You Type (SCAYT)} feature in CKEditor by default, set the {@linkapi CKEDITOR.config#scayt_autoStartup CKEDITOR.config#scayt_autoStartup} configuration setting to `true`.
 
 	config.scayt_autoStartup = true;
 
 
 ## How Do I Disable SCAYT in CKEditor?
 
-If you want to completely disable the {@link guide/dev/features/spellcheck/README#spell-check-as-you-type-%28scayt%29 Spell Check As You Type (SCAYT)} feature in CKEditor, remove the [SpellCheckAsYouType (SCAYT)](https://ckeditor.com/cke4/addon/scayt) from your CKEditor build with online builder or alternatively, disable the `scayt` plugin using the {@linkapi CKEDITOR.config#removePlugins CKEDITOR.config#removePlugins} configuration setting.
+If you want to completely disable the {@link guide/dev/features/spellcheck/README#spell-check-as-you-type-scayt Spell Check As You Type (SCAYT)} feature in CKEditor, remove the [SpellCheckAsYouType (SCAYT)](https://ckeditor.com/cke4/addon/scayt) from your CKEditor build with online builder or alternatively, disable the `scayt` plugin using the {@linkapi CKEDITOR.config#removePlugins CKEDITOR.config#removePlugins} configuration setting.
 
 	config.removePlugins = 'scayt';
 
@@ -35,7 +35,7 @@ If you want to leave SCAYT available, but prevent the feature from being turned 
 
 ## How Do I Change the Default Language for Spell Check As You Type (SCAYT)?
 
-By default {@link guide/dev/features/spellcheck/README#spell-check-as-you-type-%28scayt%29 SCAYT} treats the text written in the editor as American English (`en_US`). If you want to change the default SCAYT language, set the {@linkapi CKEDITOR.config#scayt_sLang CKEDITOR.config#scayt_sLang} configuration option to one of the 16 possible language codes that are currently accepted.
+By default {@link guide/dev/features/spellcheck/README#spell-check-as-you-type-scayt SCAYT} treats the text written in the editor as American English (`en_US`). If you want to change the default SCAYT language, set the {@linkapi CKEDITOR.config#scayt_sLang CKEDITOR.config#scayt_sLang} configuration option to one of the 16 possible language codes that are currently accepted.
 
 	// Sets SCAYT to French.
 	config.scayt_sLang = 'fr_FR';

--- a/docs/guide/dev/howtos/styles/README.md
+++ b/docs/guide/dev/howtos/styles/README.md
@@ -47,14 +47,14 @@ You can also populate the **Styles** drop-down list with style definitions added
 
 ## How Do I Add Existing CSS Styles from an External File to Editor Output and the Styles Drop-Down List?
 
-The optional [Stylesheet Parser](https://ckeditor.com/cke4/addon/stylesheetparser) plugin can be used to point to an external CSS stylesheet containing style definitions. It will help you use existing CSS styles and display them in the **Styles** drop-down list without a need to define them specifically for CKEditor as {@link guide/dev/howtos/styles/README#how-do-i-customize-the-styles-drop-down-list%3F described here}.
+The optional [Stylesheet Parser](https://ckeditor.com/cke4/addon/stylesheetparser) plugin can be used to point to an external CSS stylesheet containing style definitions. It will help you use existing CSS styles and display them in the **Styles** drop-down list without a need to define them specifically for CKEditor as {@link guide/dev/howtos/styles/README#how-do-i-customize-the-styles-drop-down-list described here}.
 
 For more information on using the plugin refer to {@link guide/dev/features/styles/README#the-stylesheet-parser-plugin The Stylesheet Parser Plugin} article and see the relevant {@linksdk styles CKEditor Examples sample}.
 
 
 ## How Do I Add Custom Styles Based on CSS Classes?
 
-Add a style definition as described in the {@link guide/dev/howtos/styles/README#how-do-i-customize-the-styles-drop-down-list%3F How Do I Customize the Styles Drop-Down List?} section above and pass the class name in the `attributes` parameter.
+Add a style definition as described in the {@link guide/dev/howtos/styles/README#how-do-i-customize-the-styles-drop-down-list How Do I Customize the Styles Drop-Down List?} section above and pass the class name in the `attributes` parameter.
 
 **Note:** Do remember that since some old browsers recognize `class` as a resereved word in JavaScript, you need to place it in quotes.
 
@@ -73,6 +73,6 @@ For more details on the definition format and best practices on how to customize
 
 ## How Do I Use the Styles on Images, Tables or Other Elements?
 
-If you added some {@link guide/dev/howtos/styles/README#how-do-i-customize-the-styles-drop-down-list%3F custom style definitions} for objects such as tables or images, you need to select these objects first before you will be able to apply the style. Object styles are only shown in the **Styles** drop-down list and can be applied *after* the element was selected in the editor as shown in the image below when the table is selected.
+If you added some {@link guide/dev/howtos/styles/README#how-do-i-customize-the-styles-drop-down-list custom style definitions} for objects such as tables or images, you need to select these objects first before you will be able to apply the style. Object styles are only shown in the **Styles** drop-down list and can be applied *after* the element was selected in the editor as shown in the image below when the table is selected.
 
 {@img assets/img/styles_03.png Object styles shown after selecting a table}

--- a/docs/guide/dev/integration/file_browse_upload/file_upload/README.md
+++ b/docs/guide/dev/integration/file_browse_upload/file_upload/README.md
@@ -207,7 +207,7 @@ For example if the response is `fileUrl|optionalErrorMessage`:
 
 ### Integration with CKFinder
 
-CKEditor can be easily integrated with [CKFinder](http://cksource.com/ckfinder), an advanced Ajax file manager. See {@link guide/dev/integration/file_browse_upload/README#using-ckfinder CKFinder Integration} for more information.
+CKEditor can be easily integrated with [CKFinder](http://cksource.com/ckfinder), an advanced Ajax file manager. See {@link guide/dev/integration/file_browse_upload/ckfinder_integration/README CKFinder Integration} for more information.
 
 <info-box info=""> Uploading dropped or pasted files will work for CKFinder 2.5+ and CKFinder 3.x.
 </info-box>

--- a/docs/guide/dev/patching/README.md
+++ b/docs/guide/dev/patching/README.md
@@ -36,7 +36,7 @@ It is unlikely that you can apply a patch to the package that you already run on
 
 ### Release Version
 
-The release version is a CKEditor package that was processed by {@link guide/dev/build/README#about-ckbuilder-%28command-line%29 CKBuilder} in order to reduce the number of files and minify the resulting code. The release version is offered for download on [CKEditor download page](https://ckeditor.com/ckeditor-4/download/) and also by the [CKEditor online builder](https://ckeditor.com/cke4/builder).
+The release version is a CKEditor package that was processed by {@link guide/dev/build/README#about-ckbuilder-command-line CKBuilder} in order to reduce the number of files and minify the resulting code. The release version is offered for download on [CKEditor download page](https://ckeditor.com/ckeditor-4/download/) and also by the [CKEditor online builder](https://ckeditor.com/cke4/builder).
 
 ### Source Version
 

--- a/docs/guide/plugin_sdk/sample/README.md
+++ b/docs/guide/plugin_sdk/sample/README.md
@@ -106,7 +106,7 @@ The {@linkapi CKEDITOR.ui.addButton CKEDITOR.ui.addButton} method call above cre
 
  * `label` &ndash; the textual part of the button (if visible) and its tooltip.
  * `command` &ndash; the command to be executed once the button is activated. This is the command we created in the previous step.
- * `toolbar` &ndash; the {@link guide/dev/features/toolbar/README#toolbar-groups-configuration toolbar group} into which the button will be added.
+ * `toolbar` &ndash; the {@link guide/dev/features/toolbarconcepts/README#toolbar-groups-configuration toolbar group} into which the button will be added.
 
 Please note that you can influence the position of the button in the toolbar group by providing an optional index, for example:
 

--- a/docs/guide/plugin_sdk/sample_1/README.md
+++ b/docs/guide/plugin_sdk/sample_1/README.md
@@ -94,7 +94,7 @@ The above {@linkapi CKEDITOR.ui.addButton CKEDITOR.ui.addButton} function call c
 
  * `label` &ndash; the textual part of the button (if visible) and its tooltip.
  * `command` &ndash; the command to be executed once the button is activated. This is the command we created in the previous step.
- * `toolbar` &ndash; the {@link guide/dev/features/toolbar/README#toolbar-groups-configuration toolbar group} into which the button will be added.
+ * `toolbar` &ndash; the {@link guide/dev/features/toolbarconcepts/README#toolbar-groups-configuration toolbar group} into which the button will be added.
 
 Please note that you can influence the position of the button in the toolbar group by providing an optional index, for example:
 

--- a/docs/sdk/examples/mentions.html
+++ b/docs/sdk/examples/mentions.html
@@ -24,7 +24,7 @@
 			<script src="assets/html5shiv.min.js"></script>
 		<![endif]-->
 		<link rel="icon" href="../template/theme/img/favicon.ico">
-		
+
 	</head>
 	<body>
 		<header class="sdk-header">
@@ -37,7 +37,7 @@
 					.chat {
 						width: 600px;
 					}
-			
+
 					.chat > .posts {
 						list-style-type: none;
 						padding: 15px;
@@ -45,58 +45,58 @@
 						border: 1px solid #d1d1d1;
 						border-bottom: none;
 					}
-			
+
 					.chat > .posts li:first-child {
 						margin-bottom: 15px;
 					}
-			
+
 					.chat > .posts .message {
 						display: inline-block;
 						margin-left: 20px;
 						width: 80%;
 					}
-			
+
 					.chat > .posts .time {
 						color: #b7b7b7;
 						font-size: .9em;
 					}
-			
+
 					.chat > .posts .photo {
 						height: 40px;
 						vertical-align: top;
 						border-radius: 15%;
 					}
-			
+
 					ul.cke_autocomplete_panel {
 						width: 250px;
 					}
-			
+
 					ul.cke_autocomplete_panel .photo {
 						display: inline-block;
 						vertical-align: middle;
 						height: 30px;
 						border-radius: 50%;
 					}
-			
+
 					.bullet {
 						padding-left: 5px;
 						padding-right: 5px;
 						color: #b7b7b7;
 					}
-			
+
 					.cke_autocomplete_panel .username {
 						padding-left: 5px;
 					}
-			
+
 					.cke_autocomplete_panel .fullname {
 						padding-left: 5px;
 						color: #b7b7b7;
 					}
-			
+
 					.sdk-contents .cke {
 						margin: 0;
 					}
-			
+
 					.sdk-contents button.send {
 						width: 100px;
 						height: 35px;
@@ -109,26 +109,26 @@
 						float: right;
 						cursor: pointer;
 					}
-			
+
 					.sdk-contents button.send:hover {
 						background-color: #027abc
 					}
-			
+
 					.sdk-contents a.mailto-user {
 						color: #b7b7b7;
 						text-decoration: underline;
 					}
-			
+
 					.sdk-contents a.mailto-user:hover {
 						color: #a0a0a0;
 					}
-			
+
 					.sdk-contents p.post-content {
 						margin: 0;
 						line-height: 19px;;
 					}
 				</style>
-				
+
 				<h1>Mentions, Tags and Emoji <a class="documentation" href="https://ckeditor.com/docs/ckeditor4/latest/guide/dev_mentions.html">Documentation</a></h1>
 
 				<p>
@@ -156,7 +156,7 @@
 								<span class="bullet">•</span>
 								<span class="time">2 hours ago</span>
 								<p class="post-content">
-								Thanks for another <a href="#yummy">#yummy</a> recipe, <a href="mailto: dwilliams@example.com">@dwilliams</a>! Makes me <a href="#hungry">#hungry</a> just looking at the photos 😋. Definitely adding it to my TODO list for our next <a href="#mediterranean">#mediterranean</a> potluck.
+								Thanks for another <a data-skip-validation="true" href="#yummy">#yummy</a> recipe, <a href="mailto: dwilliams@example.com">@dwilliams</a>! Makes me <a data-skip-validation="true" href="#hungry">#hungry</a> just looking at the photos 😋. Definitely adding it to my TODO list for our next <a data-skip-validation="true" href="#mediterranean">#mediterranean</a> potluck.
 								</p>
 							</div>
 						</li>
@@ -169,14 +169,14 @@
 								<span class="bullet">•</span>
 								<span class="time">4 hours ago</span>
 								<p class="post-content">
-								Really appreciate the <a href="#vegetarian">#vegetarian</a> and <a href="#vegan">#vegan</a> variations of your recipes. So thoughtful of you! 🌱
+								Really appreciate the <a data-skip-validation="true" href="#vegetarian">#vegetarian</a> and <a data-skip-validation="true" href="#vegan">#vegan</a> variations of your recipes. So thoughtful of you! 🌱
 								</p>
 							</div>
 						</li>
 					</ul>
 					<div class="editor">
 						<textarea cols="80" id="editor1" name="editor1" rows="10" data-sample="1" data-sample-short>
-							<p>I agree with <a href="mailto: mildred@example.com">@mwilson</a> 👍. It’s so nice of you to always be providing a few options to try! I love <a href="#greek">#greek</a> cuisine with a modern twist, this one will be perfect to try.</p>
+							<p>I agree with <a href="mailto: mildred@example.com">@mwilson</a> 👍. It’s so nice of you to always be providing a few options to try! I love <a data-skip-validation="true" href="#greek">#greek</a> cuisine with a modern twist, this one will be perfect to try.</p>
 						</textarea>
 					</div>
 					<button id="send" class="send">Send</button>
@@ -203,7 +203,7 @@
 						{ id: 8, avatar: 'm_8', fullname: 'Albert Johnson', username: 'ajohnson' },
 						{ id: 9, avatar: 'm_9', fullname: 'Steve Roberts', username: 'sroberts' },
 						{ id: 10, avatar: 'm_10', fullname: 'Kevin Evans', username: 'kevans' },
-		
+
 						{ id: 11, avatar: 'w_1', fullname: 'Mildred Wilson', username: 'mwilson' },
 						{ id: 12, avatar: 'w_2', fullname: 'Melissa Nelson', username: 'mnelson' },
 						{ id: 13, avatar: 'w_3', fullname: 'Kathleen Allen', username: 'kallen' },
@@ -279,7 +279,7 @@
 						'yum',
 						'yummy'
 					];
-		
+
 				CKEDITOR.replace( 'editor1', {
 					plugins: 'mentions,emoji,basicstyles,undo,link,wysiwygarea,toolbar',
 					contentsCss: [
@@ -312,21 +312,21 @@
 						}
 					]
 				} );
-		
+
 				function dataFeed( opts, callback ) {
 					var matchProperty = 'username',
 						data = users.filter( function( item ) {
 							return item[ matchProperty ].indexOf( opts.query.toLowerCase() ) == 0;
 						} );
-		
+
 					data = data.sort( function( a, b ) {
 						return a[ matchProperty ].localeCompare( b[ matchProperty ], undefined, { sensitivity: 'accent' } );
 					} );
-		
+
 					callback( data );
 				}
 				</script>
-		
+
 				<script>
 					CKEDITOR.instances.editor1.once( 'instanceReady', function( evt ) {
 						document.getElementById( 'send' ).addEventListener( 'click', function() {


### PR DESCRIPTION
With new link validator there was exposed bunch of links which points to incorrect place in docs. This PR fix those links to not threw errors any longer.

Close #198 