### PR TITLE
Fix incorrect path for Quail tests JSON file

### DIFF
--- a/docs/sdk/examples/accessibilitychecker.html
+++ b/docs/sdk/examples/accessibilitychecker.html
@@ -153,6 +153,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 					removePlugins: 'scayt,wsc',
 					height: 500,
 					a11ychecker_quailParams: {
+						jsonPath: 'assets/plugins/a11ychecker/libs/quail',
 						// Override Accessibility Checker guidelines from the default configuration.
 						guideline: [
 							'imgNonDecorativeHasAlt',


### PR DESCRIPTION
I've explicitly passed the path via `config.a11ychecker_quailParams.jsonPath`.

Closes #207.