### PR TITLE
Added information where to report docs issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
-All issues regarding CKEditor 4 Documentation should be reported in `ckeditor-dev` repository - https://github.com/ckeditor/ckeditor-dev/issues/new/choose.
+All issues regarding CKEditor 4 Documentation should be reported in the `ckeditor-dev` repository - https://github.com/ckeditor/ckeditor-dev/issues/new/choose.
 
 Any issues reported here still will be moved to `ckeditor-dev` repository.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
 All issues regarding CKEditor 4 Documentation should be reported in the `ckeditor-dev` repository - https://github.com/ckeditor/ckeditor-dev/issues/new/choose.
 
-Any issues reported here still will be moved to `ckeditor-dev` repository.
+Any issues reported here will be moved to the `ckeditor-dev` repository.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+All issues regarding CKEditor 4 Documentation should be reported in `ckeditor-dev` repository - https://github.com/ckeditor/ckeditor-dev/issues/new/choose.
+
+Any issues reported here still will be moved to `ckeditor-dev` repository.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the official developer documentation project for CKEditor. It uses the customized CKEditor [JSDuck clone](https://github.com/ckeditor/jsduck) for compilation and is available online at <http://docs.ckeditor.com>.
 
+**All issues regarding CKEditor 4 Documentation should be reported in [`ckeditor-dev` repository](https://github.com/ckeditor/ckeditor-dev/issues/new/choose).**
+
 ## Building the Documentation
 
 Follow the steps listed below to build CKEditor documentation locally.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the official developer documentation project for CKEditor. It uses the customized CKEditor [JSDuck clone](https://github.com/ckeditor/jsduck) for compilation and is available online at <http://docs.ckeditor.com>.
 
-**All issues regarding CKEditor 4 Documentation should be reported in [`ckeditor-dev` repository](https://github.com/ckeditor/ckeditor-dev/issues/new/choose).**
+**All issues regarding CKEditor 4 Documentation should be reported in the [`ckeditor-dev` repository](https://github.com/ckeditor/ckeditor-dev/issues/new/choose).**
 
 ## Building the Documentation
 


### PR DESCRIPTION
Since we decided that all docs related issues should be reported in `ckeditor-dev` repo, I have added some information about it.