### PR TITLE
Fixed: "Start editing" button in inline editor sample doesn't work

### DIFF
--- a/docs/sdk/examples/inline.html
+++ b/docs/sdk/examples/inline.html
@@ -300,6 +300,68 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			<li><a href="./saveajax.html">Saving Data &ndash; CKEditor in Ajax Applications</a></li>
 		</ul>
 
+		<script>
+			// Sample: Inline Editing Enabled by Code
+			(function () {
+				var isEditingEnabled,
+					toggle = document.getElementById( 'toggle' ),
+					reset = document.getElementById( 'reset' ),
+					introduction = document.getElementById( 'introduction' ),
+					introductionHTML = introduction.innerHTML;
+
+				function enableEditing() {
+					if ( !CKEDITOR.instances.introduction ) {
+						CKEDITOR.inline( 'introduction', {
+							extraAllowedContent: 'a(documentation);abbr[title];code',
+							removePlugins: 'stylescombo',
+							extraPlugins: 'sourcedialog',
+							startupFocus: true
+						} );
+					}
+				}
+
+				function disableEditing() {
+					if ( CKEDITOR.instances.introduction )
+						CKEDITOR.instances.introduction.destroy();
+				}
+
+				function toggleEditor() {
+					if ( isEditingEnabled ) {
+						if ( CKEDITOR.instances.introduction && CKEDITOR.instances.introduction.checkDirty() ) {
+							reset.style.display = 'inline';
+						}
+						disableEditing();
+						introduction.setAttribute( 'contenteditable', false );
+						this.innerHTML = 'Start editing';
+						isEditingEnabled = false;
+					}
+					else {
+						introduction.setAttribute( 'contenteditable', true );
+						enableEditing();
+						this.innerHTML = 'Finish editing';
+						isEditingEnabled = true;
+					}
+				}
+
+				function resetContent() {
+					reset.style.display = 'none';
+					introduction.innerHTML = introductionHTML;
+				}
+
+				function onClick( element, callback ) {
+					if ( window.addEventListener ) {
+						element.addEventListener( 'click', callback, false );
+					}
+					else if ( window.attachEvent ) {
+						element.attachEvent( 'onclick', callback );
+					}
+				}
+
+				onClick( toggle, toggleEditor );
+				onClick( reset, resetContent );
+
+			})();
+		</script>
 	</section>
 </section>
 
@@ -321,68 +383,6 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 			startupFocus: true
 		} );
 	&lt;/script&gt;
-</script>
-<script>
-	// Sample: Inline Editing Enabled by Code
-	(function () {
-		var isEditingEnabled,
-				toggle = document.getElementById( 'toggle' ),
-				reset = document.getElementById( 'reset' ),
-				introduction = document.getElementById( 'introduction' ),
-				introductionHTML = introduction.innerHTML;
-
-		function enableEditing() {
-			if ( !CKEDITOR.instances.introduction ) {
-				CKEDITOR.inline( 'introduction', {
-					extraAllowedContent: 'a(documentation);abbr[title];code',
-					removePlugins: 'stylescombo',
-					extraPlugins: 'sourcedialog',
-					startupFocus: true
-				} );
-			}
-		}
-
-		function disableEditing() {
-			if ( CKEDITOR.instances.introduction )
-				CKEDITOR.instances.introduction.destroy();
-		}
-
-		function toggleEditor() {
-			if ( isEditingEnabled ) {
-				if ( CKEDITOR.instances.introduction && CKEDITOR.instances.introduction.checkDirty() ) {
-					reset.style.display = 'inline';
-				}
-				disableEditing();
-				introduction.setAttribute( 'contenteditable', false );
-				this.innerHTML = 'Start editing';
-				isEditingEnabled = false;
-			}
-			else {
-				introduction.setAttribute( 'contenteditable', true );
-				enableEditing();
-				this.innerHTML = 'Finish editing';
-				isEditingEnabled = true;
-			}
-		}
-
-		function resetContent() {
-			reset.style.display = 'none';
-			introduction.innerHTML = introductionHTML;
-		}
-
-		function onClick( element, callback ) {
-			if ( window.addEventListener ) {
-				element.addEventListener( 'click', callback, false );
-			}
-			else if ( window.attachEvent ) {
-				element.attachEvent( 'onclick', callback );
-			}
-		}
-
-		onClick( toggle, toggleEditor );
-		onClick( reset, resetContent );
-
-	})();
 </script>
 <script data-sample="2">
 	// Sample: Massive Inline Editing

--- a/docs/sdk/examples/inline.html
+++ b/docs/sdk/examples/inline.html
@@ -33,17 +33,17 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 	<section class="sdk-contents">
 		<style data-sample="2">
 			/* The following styles are here just to make the "Massive Inline Editing" sample look nice. */
-		
+
 			/* A workaround to show Arial Black font in Firefox. */
 			@font-face {
 				font-family: 'arial-black';
 				src: local('Arial Black');
 			}
-		
+
 			#columns *[contenteditable="true"], #header *[contenteditable="true"] {
 				padding: 10px;
 			}
-		
+
 			#header {
 				overflow: hidden;
 				padding: 0 0 30px;
@@ -52,18 +52,18 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				color: #333;
 				background-color: #f9f9f9;
 			}
-		
+
 			#headerLeft,
 			#headerRight {
 				width: 49%;
 				overflow: hidden;
 			}
-		
+
 			#headerLeft {
 				float: left;
 				padding: 10px 1px 1px;
 			}
-		
+
 			#headerLeft h2,
 			#headerLeft h3 {
 				text-align: right;
@@ -71,43 +71,43 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				overflow: hidden;
 				font-weight: normal;
 			}
-		
+
 			#headerLeft h2 {
 				font-family: "Arial Black", arial-black;
 				font-size: 3.6em;
 				line-height: 1.1;
 				text-transform: uppercase;
 			}
-		
+
 			#headerLeft h3 {
 				font-size: 1.9em;
 				line-height: 1.1;
 				margin: .2em 0 0;
 				color: #666;
 			}
-		
+
 			#headerRight {
 				float: right;
 				padding: 1px;
 			}
-		
+
 			#headerRight p {
 				line-height: 1.8;
 				text-align: justify;
 				margin: 0;
 			}
-		
+
 			#headerRight p + p {
 				margin-top: 20px;
 			}
-		
+
 			#headerRight > div {
 				padding: 20px;
 				margin: 0 0 0 30px;
 				font-size: 1.2em;
 				color: #666;
 			}
-		
+
 			#columns {
 				color: #333;
 				overflow: hidden;
@@ -115,29 +115,28 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 				font-size: 0.9em;
 				background-color: #f9f9f9;
 			}
-		
+
 			#columns > div {
 				float: left;
 				width: 33.3%;
 			}
-		
+
 			#columns #column1 > div {
 				margin-left: 1px;
 			}
-		
+
 			#columns #column3 > div {
 				margin-right: 1px;
 			}
-		
+
 			#columns > div > div {
 				margin: 0px 10px;
 				padding: 10px 20px;
 			}
-		
+
 			#columns blockquote {
 				margin-left: 15px;
 			}
-		
 		</style>
 
 		<div data-sample="1" id="introduction">
@@ -302,7 +301,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 		<script>
 			// Sample: Inline Editing Enabled by Code
-			(function () {
+			( function() {
 				var isEditingEnabled,
 					toggle = document.getElementById( 'toggle' ),
 					reset = document.getElementById( 'reset' ),
@@ -359,8 +358,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license.
 
 				onClick( toggle, toggleEditor );
 				onClick( reset, resetContent );
-
-			})();
+			} )();
 		</script>
 	</section>
 </section>


### PR DESCRIPTION
`<script>` tag declared at the bottom of file are treated by umberto as code samples. Moved the script for inline editing up in DOM tree, so it's not removed by bender.

Closes https://github.com/ckeditor/ckeditor-dev/issues/2883
