### PR TITLE
Updated Getting Started docs page

### DIFF
--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -14,15 +14,25 @@ For licensing, see LICENSE.md.
 
 The aim of this article is to get you up and running with CKEditor in two minutes.
 
-## Download
+## Download from Official Site
+
+### Download
 
 Visit the official [CKEditor Download](https://ckeditor.com/ckeditor-4/download/) site. For a production site we recommend you choose the default **Standard Package** and click the **Download CKEditor** button to get the `.zip` installation file. If you want to try out more editor features, you can download the **Full Package** instead.
 
 <a href="https://ckeditor.com/ckeditor-4/download/"><img src="%BASE_PATH%/assets/img/ckeditor_quick_start_download.png" alt="CKEditor Download site" width="914" height="440"/></a>
 
-## Unpacking
+### Unpacking
 
 Unpack (extract) the downloaded `.zip` archive to the `ckeditor` directory in the root of your website.
+
+## Install from the NPM registry
+
+To install [the CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor):
+
+```bash
+npm install --save ckeditor
+```
 
 ## Trying Out
 
@@ -30,6 +40,9 @@ CKEditor comes with a sample that you can check to verify if the installation wa
 
 Open the following page in the browser to see the sample:
 `http://<your site="">/ckeditor/samples/index.html`
+
+When using the NPM package open the following:
+`http://<your site="">/node_modules/ckeditor/samples/index.html`
 
 <img src="%BASE_PATH%/assets/img/ckeditor_sample.png" alt="CKEditor sample available in each installation package" width="802" height="530">
 
@@ -79,6 +92,24 @@ When you are done, open your test page in the browser.
 ## Using the CDN
 
 Instead of downloading CKEditor to your server and hosting it you can also use the CDN version. Go to the [official CKEditor CDN](http://cdn.ckeditor.com/) page for more details.
+
+## CKEditor Framework Integrations:
+
+CKEditor 4 supported frameworks:
+
+### [CKEditor 4 React Integration](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_react.html):
+
+```bash
+npm install --save ckeditor4-react
+```
+
+### [CKEditor 4 Angular Integration](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html):
+
+```bash
+npm install --save ckeditor4-angular
+```
+
+CKEditor Vue Integration is under developement.
 
 ## Next Steps
 

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -22,7 +22,7 @@ To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/c
 npm install --save ckeditor
 ```
 
-For more detailed information you can check guide {@link guide/dev/package_managers/README Installing CKEditor with Package Managers}.
+For more detailed information you can check the guide on {@link guide/dev/package_managers/README Installing CKEditor 4 with Package Managers}.
 
 ## Download from Official Site
 
@@ -40,31 +40,31 @@ Unpack (extract) the downloaded `.zip` archive to the `ckeditor` directory in th
 
 Instead of downloading CKEditor to your server and hosting it you can also use the CDN version. Go to the [official CKEditor CDN](http://cdn.ckeditor.com/) page for more details.
 
-## CKEditor 4 Framework Integrations
+## Integrate with popular frameworks
 
 ### CKEditor 4 Angular Integration
 
-To install the Official CKEditor 4 Angular Component package run:
+To install the Official CKEditor 4 Angular Component run:
 
 ```bash
 npm install --save ckeditor4-angular
 ```
 
-By default it will automatically fetch latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/angular/README integration guides} on how it can be changed and how to configure the component to fit you needs.
+By default it will automatically fetch the latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/angular/README integration guides} on how it can be changed and how to configure the component to fit you needs.
 
 ### CKEditor 4 React Integration
 
-To install the Official CKEditor 4 React Component package run:
+To install the Official CKEditor 4 React Component run:
 
 ```bash
 npm install --save ckeditor4-react
 ```
 
-By default it will automatically fetch latest CKEditor 4  [Standard preset](https://ckeditor.com/cke4/presets-all)  via CDN. Check the {@link guide/dev/integration/react/README integration guides} on how it can be changed and how to configure the component to fit you needs.
+By default it will automatically fetch the latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/react/README integration guides} on how it can be changed and how to configure the component to fit you needs.
 
 ### CKEditor 4 Vue Integration
 
-CKEditor Vue Integration is under developement.
+{@link guide/dev/integration/vue/README CKEditor 4 Vue Integration} is under development.
 
 ## Trying Out
 

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -34,6 +34,8 @@ To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/c
 npm install --save ckeditor
 ```
 
+For more detailed information you can check guide {@link guide/dev/package_managers/README Installing CKEditor with Package Managers}.
+
 ## Trying Out
 
 CKEditor comes with a sample that you can check to verify if the installation was successful as well as a few "next steps" ideas and references to further resources.

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -28,7 +28,7 @@ Unpack (extract) the downloaded `.zip` archive to the `ckeditor` directory in th
 
 ## Install from the NPM registry
 
-To install [the CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor):
+To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor) run:
 
 ```bash
 npm install --save ckeditor

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -95,8 +95,6 @@ Instead of downloading CKEditor to your server and hosting it you can also use t
 
 ## CKEditor 4 Framework Integrations
 
-CKEditor 4 supported frameworks:
-
 ### [CKEditor 4 React Integration](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_react.html):
 
 ```bash

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -14,6 +14,16 @@ For licensing, see LICENSE.md.
 
 The aim of this article is to get you up and running with CKEditor in two minutes.
 
+## Install from the NPM registry
+
+To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor) run:
+
+```bash
+npm install --save ckeditor
+```
+
+For more detailed information you can check guide {@link guide/dev/package_managers/README Installing CKEditor with Package Managers}.
+
 ## Download from Official Site
 
 ### Download
@@ -26,15 +36,35 @@ Visit the official [CKEditor Download](https://ckeditor.com/ckeditor-4/download/
 
 Unpack (extract) the downloaded `.zip` archive to the `ckeditor` directory in the root of your website.
 
-## Install from the NPM registry
+## Using the CDN
 
-To install [the official CKEditor 4 NPM package](https://www.npmjs.com/package/ckeditor) run:
+Instead of downloading CKEditor to your server and hosting it you can also use the CDN version. Go to the [official CKEditor CDN](http://cdn.ckeditor.com/) page for more details.
+
+## CKEditor 4 Framework Integrations
+
+### CKEditor 4 Angular Integration
+
+To install the Official CKEditor 4 Angular Component package run:
 
 ```bash
-npm install --save ckeditor
+npm install --save ckeditor4-angular
 ```
 
-For more detailed information you can check guide {@link guide/dev/package_managers/README Installing CKEditor with Package Managers}.
+By default it will automatically fetch latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/angular/README integration guides} on how it can be changed and how to configure the component to fit you needs.
+
+### CKEditor 4 React Integration
+
+To install the Official CKEditor 4 React Component package run:
+
+```bash
+npm install --save ckeditor4-react
+```
+
+By default it will automatically fetch latest CKEditor 4  [Standard preset](https://ckeditor.com/cke4/presets-all)  via CDN. Check the {@link guide/dev/integration/react/README integration guides} on how it can be changed and how to configure the component to fit you needs.
+
+### CKEditor 4 Vue Integration
+
+CKEditor Vue Integration is under developement.
 
 ## Trying Out
 
@@ -90,36 +120,6 @@ When you are done, open your test page in the browser.
 **Congratulations! You have just installed and used CKEditor on your own page in virtually no time!**
 
 {@img assets/img/ckeditor_on_page.png CKEditor added to your sample page}
-
-## Using the CDN
-
-Instead of downloading CKEditor to your server and hosting it you can also use the CDN version. Go to the [official CKEditor CDN](http://cdn.ckeditor.com/) page for more details.
-
-## CKEditor 4 Framework Integrations
-
-### CKEditor 4 React Integration
-
-To install the Official CKEditor 4 React Component package run:
-
-```bash
-npm install --save ckeditor4-react
-```
-
-By default it will automatically fetch latest CKEditor 4  [Standard preset](https://ckeditor.com/cke4/presets-all)  via CDN. Check the {@link guide/dev/integration/react/README integration guides} on how it can be changed and how to configure the component to fit you needs.
-
-### CKEditor 4 Angular Integration
-
-To install the Official CKEditor 4 Angular Component package run:
-
-```bash
-npm install --save ckeditor4-angular
-```
-
-By default it will automatically fetch latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/angular/README integration guides} on how it can be changed and how to configure the component to fit you needs.
-
-### CKEditor 4 Vue Integration
-
-CKEditor Vue Integration is under developement.
 
 ## Next Steps
 

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -93,7 +93,7 @@ When you are done, open your test page in the browser.
 
 Instead of downloading CKEditor to your server and hosting it you can also use the CDN version. Go to the [official CKEditor CDN](http://cdn.ckeditor.com/) page for more details.
 
-## CKEditor Framework Integrations:
+## CKEditor 4 Framework Integrations
 
 CKEditor 4 supported frameworks:
 

--- a/docs/guide/dev/installation/README.md
+++ b/docs/guide/dev/installation/README.md
@@ -95,17 +95,27 @@ Instead of downloading CKEditor to your server and hosting it you can also use t
 
 ## CKEditor 4 Framework Integrations
 
-### [CKEditor 4 React Integration](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_react.html):
+### CKEditor 4 React Integration
+
+To install the Official CKEditor 4 React Component package run:
 
 ```bash
 npm install --save ckeditor4-react
 ```
 
-### [CKEditor 4 Angular Integration](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html):
+By default it will automatically fetch latest CKEditor 4  [Standard preset](https://ckeditor.com/cke4/presets-all)  via CDN. Check the {@link guide/dev/integration/react/README integration guides} on how it can be changed and how to configure the component to fit you needs.
+
+### CKEditor 4 Angular Integration
+
+To install the Official CKEditor 4 Angular Component package run:
 
 ```bash
 npm install --save ckeditor4-angular
 ```
+
+By default it will automatically fetch latest CKEditor 4 [Standard-All preset](https://ckeditor.com/cke4/presets-all) via CDN. Check the {@link guide/dev/integration/angular/README integration guides} on how it can be changed and how to configure the component to fit you needs.
+
+### CKEditor 4 Vue Integration
 
 CKEditor Vue Integration is under developement.
 


### PR DESCRIPTION
I've added sections about installing from NPM, and section about frameworks.
"Unpacking" section is grouped together with "Download" under new section "Download from Official Site", this is because npm package doesn't need unpacking process, so it's less misleading this way.

Closes https://github.com/ckeditor/ckeditor-dev/issues/2999